### PR TITLE
Enhance CI workflow with version bumping and test integration

### DIFF
--- a/.github/workflows/main_flutter_build.yml
+++ b/.github/workflows/main_flutter_build.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
 
   test:
@@ -22,13 +25,50 @@ jobs:
           envkey_PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
       - run: flutter pub get
       - name: Run tests
-        run: flutter test test/core/ test/features/
+        run: flutter test test/core/ test/features/ test/l10n/
+
+  version-bump:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.bump.outputs.commit_sha }}
+      new_version: ${{ steps.bump.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Bump patch version
+        id: bump
+        run: |
+          CURRENT_VERSION=$(grep -E "^version:" pubspec.yaml | sed 's/version: //')
+          VERSION_PART=$(echo "$CURRENT_VERSION" | cut -d'+' -f1)
+          MAJOR=$(echo "$VERSION_PART" | cut -d'.' -f1)
+          MINOR=$(echo "$VERSION_PART" | cut -d'.' -f2)
+          PATCH=$(echo "$VERSION_PART" | cut -d'.' -f3)
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}+1"
+
+          sed -i "s/^version: .*/version: $NEW_VERSION/" pubspec.yaml
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pubspec.yaml
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          git tag -a "v$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push && git push --tags
+
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
   build-windows:
-    needs: test
+    needs: [test, version-bump]
+    if: ${{ !cancelled() && needs.test.result == 'success' && needs.version-bump.result != 'failure' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version-bump.outputs.commit_sha || github.sha }}
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.41.2'
@@ -56,10 +96,13 @@ jobs:
           path: build/windows/x64/runner/Release/
 
   build-linux:
-    needs: test
+    needs: [test, version-bump]
+    if: ${{ !cancelled() && needs.test.result == 'success' && needs.version-bump.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version-bump.outputs.commit_sha || github.sha }}
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.41.2'
@@ -84,10 +127,13 @@ jobs:
           path: build/linux/x64/release/bundle/
 
   build-android:
-    needs: test
+    needs: [test, version-bump]
+    if: ${{ !cancelled() && needs.test.result == 'success' && needs.version-bump.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version-bump.outputs.commit_sha || github.sha }}
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'


### PR DESCRIPTION
- Added a new job to automatically bump the patch version in pubspec.yaml after successful tests, ensuring versioning is managed consistently.
- Updated test job to include localization tests, improving coverage and reliability.
- Modified build jobs to depend on both test and version bump jobs, ensuring builds are based on the latest version and passing tests.
- Adjusted permissions for the workflow to allow writing to repository contents.

These changes streamline the CI process, enhancing version management and ensuring builds are based on validated code.