### PR TITLE
124 add automatic version bumping on merge to main (#131)

### DIFF
--- a/.github/workflows/main_flutter_build.yml
+++ b/.github/workflows/main_flutter_build.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
       - name: Bump patch version
         id: bump
         run: |


### PR DESCRIPTION
* Enhance CI workflow with version bumping and test integration

- Added a new job to automatically bump the patch version in pubspec.yaml after successful tests, ensuring versioning is managed consistently.
- Updated test job to include localization tests, improving coverage and reliability.
- Modified build jobs to depend on both test and version bump jobs, ensuring builds are based on the latest version and passing tests.
- Adjusted permissions for the workflow to allow writing to repository contents.

These changes streamline the CI process, enhancing version management and ensuring builds are based on validated code.

* update tech_stack

* update tech_stack

* update tech_stack