### PR TITLE
feat: add integration tests for diary entry and note search workflows

### DIFF
--- a/.github/workflows/main_flutter_build.yml
+++ b/.github/workflows/main_flutter_build.yml
@@ -25,7 +25,7 @@ jobs:
           envkey_PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
       - run: flutter pub get
       - name: Run tests
-        run: flutter test test/core/ test/features/ test/l10n/
+        run: flutter test test/core/ test/features/ test/l10n/ test/integration/
 
   version-bump:
     needs: test

--- a/test/TEST_COVERAGE.md
+++ b/test/TEST_COVERAGE.md
@@ -1,10 +1,10 @@
 # Test Coverage
 
-**Total: 815 passing tests** across 55 test files (+ 16 optional/skipped Supabase integration tests)
+**Total: 851+ passing tests** across 59 test files (+ 16 optional/skipped Supabase integration tests)
 
 Run all tests with:
 ```bash
-flutter test test/core/ test/features/ test/l10n/
+flutter test test/core/ test/features/ test/l10n/ test/integration/
 ```
 
 ---
@@ -234,6 +234,44 @@ flutter test test/core/ test/features/ test/l10n/
 
 ---
 
+## Integration Tests (`test/integration/`)
+
+Workflow-level tests that verify multi-feature provider interactions using `ProviderContainer` and `TestDbRepository`.
+
+### Diary Entry Workflow (`test/integration/diary_entry_workflow_test.dart`)
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `diary_entry_workflow_test.dart` | 9 | **Provider chain:** DayRatingsNotifier updates, DiaryDay construction + save, `diaryDayFullDataProvider` note association, `isDiaryOfDayCompleteProvider` (complete/empty). **Wizard providers:** `wizardDayNotesProvider` date filtering, dynamic note addition, `createEmptyNoteProvider` defaults. **Enhanced rating:** resets on date change |
+
+**Sources:** `lib/features/day_rating/domain/providers/diary_wizard_providers.dart`, `diary_day_local_db_provider.dart`
+
+### Note Search Workflow (`test/integration/note_search_workflow_test.dart`)
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `note_search_workflow_test.dart` | 9 | **Full provider chain:** notes appear in `filteredNotesProvider`, text search filters in real-time, category filter, combined category+text search, date range filter, `clearAll` resets, adding note while filter active updates results, deleting note updates results, favorites filter |
+
+**Sources:** `lib/features/notes/domain/providers/note_local_db_provider.dart`, `note_search_provider.dart`
+
+### Settings Persistence Workflow (`test/integration/settings_persistence_workflow_test.dart`)
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `settings_persistence_workflow_test.dart` | 7 | **Cross-provider persistence:** theme seed color survives `ThemeProvider` recreation, dark mode toggle + restore, default seed color, locale auto-persists to `settingsContainer`, locale survives recreation, combined theme+locale+dark mode workflow, independent user settings, ThemeProvider vs LocaleProvider persistence asymmetry |
+
+**Sources:** `lib/core/provider/theme_provider.dart`, `locale_provider.dart`, `lib/core/settings/settings_container.dart`
+
+### Export/Import Workflow (`test/integration/export_import_workflow_test.dart`)
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `export_import_workflow_test.dart` | 10 | **Data round-trip with notes:** diary days with embedded notes, multiple days with mixed content, file-based round-trip, encrypted round-trip preserves notes, import populates provider state. **Cross-feature integrity:** note categories preserved, all 4 DayRating types, EnhancedDayRating (PERMA+), empty data, large dataset (30 days) |
+
+**Sources:** `lib/features/synchronization/domain/providers/file_db_provider.dart`, `lib/features/synchronization/data/models/export_data.dart`
+
+---
+
 ## Coverage Summary by Area
 
 | Area | Status | Notes |
@@ -268,14 +306,17 @@ flutter test test/core/ test/features/ test/l10n/
 | Dashboard granular providers | Covered | currentStreakProvider, todayLoggedProvider, weekAverageProvider: value extraction, default before load, selective rebuild |
 | Widget: NewDashboardPage | Covered | FAB, RefreshIndicator, responsive layout, custom stats rendering |
 | Widget: SettingsPage | Covered | Settings title, all 6 settings sections, category management, scrollability |
+| Integration: Diary entry workflow | Covered | Provider chain + wizard providers + enhanced rating reset |
+| Integration: Note search workflow | Covered | Full filteredNotesProvider chain with CRUD + filters |
+| Integration: Settings persistence | Covered | Cross-provider state + restart simulation |
+| Integration: Export/import round-trip | Covered | Notes in diary days, encryption, large datasets |
 
-### Not covered (requires integration tests)
+### Not covered
 
 | Area | Reason |
 |------|--------|
-| Riverpod provider state (with ProviderContainer) | Requires mocking database layer |
-| SQLite database operations (LocalDbHelper) | Requires real/mock SQLite database |
-| File picker / permission handler | Platform-specific, requires integration tests |
+| SQLite database operations (LocalDbHelper) | Requires real SQLite database |
+| File picker / permission handler | Platform-specific, requires device |
 
 ---
 

--- a/test/helpers/integration_test_fixtures.dart
+++ b/test/helpers/integration_test_fixtures.dart
@@ -1,0 +1,76 @@
+import 'package:day_tracker/features/day_rating/data/models/day_rating.dart';
+import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
+import 'package:day_tracker/features/day_rating/data/models/enhanced_day_rating.dart';
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/data/models/note_category.dart';
+import 'package:flutter/material.dart';
+
+// ── Categories ───────────────────────────────────────────────────────────────
+
+final workCategory = NoteCategory(title: 'Work', color: Colors.purple);
+final leisureCategory = NoteCategory(title: 'Leisure', color: Colors.lightBlue);
+final foodCategory = NoteCategory(title: 'Food', color: Colors.amber);
+
+List<NoteCategory> get integrationTestCategories =>
+    [workCategory, leisureCategory, foodCategory];
+
+// ── Note Factory ─────────────────────────────────────────────────────────────
+
+Note makeTestNote({
+  String? id,
+  String title = 'Test Note',
+  String description = 'Test Description',
+  required DateTime from,
+  Duration duration = const Duration(hours: 1),
+  NoteCategory? category,
+  bool isFavorite = false,
+  bool isAllDay = false,
+}) {
+  return Note(
+    id: id,
+    title: title,
+    description: description,
+    from: from,
+    to: from.add(duration),
+    noteCategory: category ?? workCategory,
+    isFavorite: isFavorite,
+    isAllDay: isAllDay,
+  );
+}
+
+// ── Ratings ──────────────────────────────────────────────────────────────────
+
+List<DayRating> get defaultRatings => [
+      DayRating(dayRating: DayRatings.social, score: 4),
+      DayRating(dayRating: DayRatings.productivity, score: 3),
+      DayRating(dayRating: DayRatings.sport, score: 5),
+      DayRating(dayRating: DayRatings.food, score: 4),
+    ];
+
+// ── DiaryDay Factory ─────────────────────────────────────────────────────────
+
+DiaryDay makeTestDiaryDay({
+  required DateTime day,
+  List<DayRating>? ratings,
+  List<Note>? notes,
+  bool isFavorite = false,
+  EnhancedDayRating? enhancedRating,
+}) {
+  final diaryDay = DiaryDay(
+    day: day,
+    ratings: ratings ?? defaultRatings,
+    isFavorite: isFavorite,
+    enhancedRating: enhancedRating,
+  );
+  diaryDay.notes = notes ?? [];
+  return diaryDay;
+}
+
+// ── Dates ────────────────────────────────────────────────────────────────────
+
+/// A fixed reference date for deterministic tests.
+final referenceDate = DateTime(2026, 2, 20);
+
+/// Creates a DateTime offset from [referenceDate] by [daysOffset].
+DateTime dateAt(int daysOffset) =>
+    referenceDate.add(Duration(days: daysOffset));

--- a/test/integration/diary_entry_workflow_test.dart
+++ b/test/integration/diary_entry_workflow_test.dart
@@ -1,0 +1,358 @@
+import 'package:day_tracker/features/day_rating/data/models/day_rating.dart';
+import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
+import 'package:day_tracker/features/day_rating/data/models/enhanced_day_rating.dart';
+import 'package:day_tracker/features/day_rating/domain/providers/diary_day_local_db_provider.dart';
+import 'package:day_tracker/features/day_rating/domain/providers/diary_wizard_providers.dart';
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/domain/providers/category_local_db_provider.dart';
+import 'package:day_tracker/features/notes/domain/providers/note_local_db_provider.dart';
+import 'package:day_tracker/features/notes/domain/providers/note_selected_date_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/integration_test_fixtures.dart';
+import '../helpers/widget_test_helpers.dart';
+
+void main() {
+  setUpAll(() => initTestSettingsContainer());
+
+  group('Diary Entry Workflow', () {
+    group('provider chain: ratings -> diary day -> persistence', () {
+      test('DayRatingsNotifier updates propagate correctly', () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(dayRatingsProvider.notifier);
+
+        // Default: all ratings at score 3
+        final initial = container.read(dayRatingsProvider);
+        expect(initial, hasLength(4));
+        expect(initial.every((r) => r.score == 3), isTrue);
+
+        // Update each rating
+        notifier.updateRating(DayRatings.social, 5);
+        notifier.updateRating(DayRatings.productivity, 2);
+        notifier.updateRating(DayRatings.sport, 4);
+        notifier.updateRating(DayRatings.food, 1);
+
+        final updated = container.read(dayRatingsProvider);
+        expect(
+          updated.firstWhere((r) => r.dayRating == DayRatings.social).score,
+          5,
+        );
+        expect(
+          updated.firstWhere((r) => r.dayRating == DayRatings.productivity).score,
+          2,
+        );
+        expect(
+          updated.firstWhere((r) => r.dayRating == DayRatings.sport).score,
+          4,
+        );
+        expect(
+          updated.firstWhere((r) => r.dayRating == DayRatings.food).score,
+          1,
+        );
+      });
+
+      test('constructing DiaryDay from ratings and saving to provider', () async {
+        final container = ProviderContainer(overrides: [
+          diaryDayLocalDbDataProvider.overrideWith(
+            (_) => TestDbRepository<DiaryDay>(
+              tableName: DiaryDay.tableName,
+              columns: DiaryDay.columns,
+              fromMap: DiaryDay.fromDbMap,
+            ),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        // Build ratings
+        final ratingsNotifier = container.read(dayRatingsProvider.notifier);
+        ratingsNotifier.updateRating(DayRatings.social, 5);
+        ratingsNotifier.updateRating(DayRatings.productivity, 4);
+        ratingsNotifier.updateRating(DayRatings.sport, 3);
+        ratingsNotifier.updateRating(DayRatings.food, 4);
+
+        // Construct and save diary day (mirrors _saveLegacyDay logic)
+        final ratings = container.read(dayRatingsProvider);
+        final diaryDay = DiaryDay(
+          day: DateTime(2026, 2, 20),
+          ratings: ratings,
+        );
+
+        await container
+            .read(diaryDayLocalDbDataProvider.notifier)
+            .addElement(diaryDay);
+
+        // Verify persistence
+        final saved = container.read(diaryDayLocalDbDataProvider);
+        expect(saved, hasLength(1));
+        expect(saved.first.overallScore, 5 + 4 + 3 + 4);
+      });
+
+      test('diaryDayFullDataProvider associates notes with diary days', () async {
+        final today = DateTime(2026, 2, 20);
+        final testNotes = [
+          makeTestNote(
+            title: 'Morning',
+            from: DateTime(2026, 2, 20, 9, 0),
+          ),
+          makeTestNote(
+            title: 'Evening',
+            from: DateTime(2026, 2, 20, 18, 0),
+          ),
+          // Note on a different day — should not be associated
+          makeTestNote(
+            title: 'Yesterday',
+            from: DateTime(2026, 2, 19, 12, 0),
+          ),
+        ];
+        final diaryDay = DiaryDay(day: today, ratings: defaultRatings);
+
+        final container = ProviderContainer(overrides: [
+          diaryDayLocalDbDataProvider.overrideWith(
+            (_) => TestDbRepository<DiaryDay>(
+              tableName: DiaryDay.tableName,
+              columns: DiaryDay.columns,
+              fromMap: DiaryDay.fromDbMap,
+              initialData: [diaryDay],
+            ),
+          ),
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+              initialData: testNotes,
+            ),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        final fullDays = container.read(diaryDayFullDataProvider);
+
+        expect(fullDays, hasLength(1));
+        expect(fullDays.first.notes, hasLength(2));
+        expect(
+          fullDays.first.notes.map((n) => n.title),
+          containsAll(['Morning', 'Evening']),
+        );
+      });
+
+      test('isDiaryOfDayCompleteProvider returns true after saving all ratings',
+          () async {
+        final today = DateTime(2026, 2, 20);
+        final diaryDay = DiaryDay(day: today, ratings: defaultRatings);
+
+        final container = ProviderContainer(overrides: [
+          diaryDayLocalDbDataProvider.overrideWith(
+            (_) => TestDbRepository<DiaryDay>(
+              tableName: DiaryDay.tableName,
+              columns: DiaryDay.columns,
+              fromMap: DiaryDay.fromDbMap,
+              initialData: [diaryDay],
+            ),
+          ),
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+            ),
+          ),
+          categoryLocalDataProvider.overrideWith(
+            (_) => TestCategoryProvider(integrationTestCategories),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        // Set selected date to today so isDiaryOfDayCompleteProvider evaluates
+        container
+            .read(noteSelectedDateProvider.notifier)
+            .updateSelectedDate(today);
+
+        // Allow microtasks to settle
+        await Future<void>.delayed(Duration.zero);
+
+        final isComplete = container.read(isDiaryOfDayCompleteProvider);
+        expect(isComplete, isTrue);
+      });
+
+      test('isDiaryOfDayCompleteProvider returns false with no diary day', () {
+        final container = ProviderContainer(overrides: [
+          diaryDayLocalDbDataProvider.overrideWith(
+            (_) => TestDbRepository<DiaryDay>(
+              tableName: DiaryDay.tableName,
+              columns: DiaryDay.columns,
+              fromMap: DiaryDay.fromDbMap,
+            ),
+          ),
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+            ),
+          ),
+          categoryLocalDataProvider.overrideWith(
+            (_) => TestCategoryProvider(integrationTestCategories),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        final isComplete = container.read(isDiaryOfDayCompleteProvider);
+        expect(isComplete, isFalse);
+      });
+    });
+
+    group('wizard note providers integration', () {
+      test('wizardDayNotesProvider filters notes to selected date', () {
+        final testNotes = [
+          makeTestNote(
+            title: 'Today Note',
+            from: DateTime(2026, 2, 20, 9, 0),
+          ),
+          makeTestNote(
+            title: 'Tomorrow Note',
+            from: DateTime(2026, 2, 21, 9, 0),
+          ),
+        ];
+
+        final container = ProviderContainer(overrides: [
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+              initialData: testNotes,
+            ),
+          ),
+          categoryLocalDataProvider.overrideWith(
+            (_) => TestCategoryProvider(integrationTestCategories),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        // Set wizard date to Feb 20
+        container
+            .read(wizardSelectedDateProvider.notifier)
+            .updateSelectedDate(DateTime(2026, 2, 20));
+
+        final wizardNotes = container.read(wizardDayNotesProvider);
+        expect(wizardNotes, hasLength(1));
+        expect(wizardNotes.first.title, 'Today Note');
+      });
+
+      test('adding note to provider updates wizardDayNotesProvider', () async {
+        final container = ProviderContainer(overrides: [
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+            ),
+          ),
+          categoryLocalDataProvider.overrideWith(
+            (_) => TestCategoryProvider(integrationTestCategories),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        // Set wizard date
+        container
+            .read(wizardSelectedDateProvider.notifier)
+            .updateSelectedDate(DateTime(2026, 2, 20));
+
+        expect(container.read(wizardDayNotesProvider), isEmpty);
+
+        // Add a note for that date
+        await container.read(notesLocalDataProvider.notifier).addElement(
+              makeTestNote(
+                title: 'New Note',
+                from: DateTime(2026, 2, 20, 10, 0),
+              ),
+            );
+
+        expect(container.read(wizardDayNotesProvider), hasLength(1));
+      });
+
+      test('createEmptyNoteProvider uses default category and next time slot',
+          () {
+        final container = ProviderContainer(overrides: [
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+            ),
+          ),
+          categoryLocalDataProvider.overrideWith(
+            (_) => TestCategoryProvider(integrationTestCategories),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        container
+            .read(wizardSelectedDateProvider.notifier)
+            .updateSelectedDate(DateTime(2026, 2, 20));
+
+        final emptyNote = container.read(createEmptyNoteProvider);
+
+        // Should have an empty title
+        expect(emptyNote.title, isEmpty);
+        // Should use default category (first in list)
+        expect(emptyNote.noteCategory.title, 'Work');
+        // Should start at 7:00 (day start, since no notes exist)
+        expect(emptyNote.from.hour, 7);
+        expect(emptyNote.from.minute, 0);
+        // Duration should be 30 minutes
+        expect(
+          emptyNote.to.difference(emptyNote.from).inMinutes,
+          30,
+        );
+      });
+    });
+
+    group('enhanced day rating provider integration', () {
+      test('enhanced rating resets when wizard date changes', () {
+        final container = ProviderContainer(overrides: [
+          notesLocalDataProvider.overrideWith(
+            (_) => TestDbRepository<Note>(
+              tableName: Note.tableName,
+              columns: Note.columns,
+              fromMap: Note.fromDbMap,
+            ),
+          ),
+          categoryLocalDataProvider.overrideWith(
+            (_) => TestCategoryProvider(integrationTestCategories),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        // Set date and modify enhanced rating
+        container
+            .read(wizardSelectedDateProvider.notifier)
+            .updateSelectedDate(DateTime(2026, 2, 20));
+
+        container.read(enhancedDayRatingProvider.notifier).updateWellbeing(
+              const WellbeingRating(mood: 4, energy: 3),
+            );
+
+        expect(
+          container.read(enhancedDayRatingProvider).wellbeing.mood,
+          4,
+        );
+
+        // Change date — enhanced rating should reset
+        container
+            .read(wizardSelectedDateProvider.notifier)
+            .updateSelectedDate(DateTime(2026, 2, 21));
+
+        expect(
+          container.read(enhancedDayRatingProvider).wellbeing.mood,
+          0,
+        );
+      });
+    });
+  });
+}

--- a/test/integration/export_import_workflow_test.dart
+++ b/test/integration/export_import_workflow_test.dart
@@ -1,0 +1,324 @@
+import 'dart:io';
+
+import 'package:day_tracker/core/authentication/password_auth_service.dart';
+import 'package:day_tracker/features/day_rating/data/models/day_rating.dart';
+import 'package:day_tracker/features/day_rating/data/models/enhanced_day_rating.dart';
+import 'package:day_tracker/features/synchronization/data/models/export_data.dart';
+import 'package:day_tracker/features/synchronization/domain/providers/file_db_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/integration_test_fixtures.dart';
+
+void main() {
+  late FileDbProvider provider;
+  late Directory tempDir;
+
+  setUp(() {
+    provider = FileDbProvider();
+    tempDir = Directory.systemTemp.createTempSync('integration_export_');
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  group('Export/Import Workflow', () {
+    group('full data round-trip with notes', () {
+      test('diary days with embedded notes survive export/import', () {
+        final notes = [
+          makeTestNote(
+            title: 'Morning Standup',
+            from: DateTime(2026, 2, 20, 9, 0),
+            category: workCategory,
+          ),
+          makeTestNote(
+            title: 'Lunch',
+            from: DateTime(2026, 2, 20, 12, 0),
+            category: foodCategory,
+          ),
+        ];
+        final diaryDay = makeTestDiaryDay(
+          day: DateTime(2026, 2, 20),
+          notes: notes,
+        );
+
+        final exported = provider.exportToString(
+          diaryDays: [diaryDay],
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+
+        expect(imported.data, hasLength(1));
+        expect(imported.data.first.notes, hasLength(2));
+        expect(imported.data.first.notes[0].title, 'Morning Standup');
+        expect(imported.data.first.notes[1].title, 'Lunch');
+      });
+
+      test('multiple diary days with mixed content round-trip', () {
+        final dayWithNotes = makeTestDiaryDay(
+          day: DateTime(2026, 2, 20),
+          notes: [
+            makeTestNote(title: 'Note A', from: DateTime(2026, 2, 20, 9, 0)),
+            makeTestNote(title: 'Note B', from: DateTime(2026, 2, 20, 14, 0)),
+          ],
+        );
+        final dayWithoutNotes = makeTestDiaryDay(
+          day: DateTime(2026, 2, 21),
+          notes: [],
+        );
+        final dayWithManyNotes = makeTestDiaryDay(
+          day: DateTime(2026, 2, 22),
+          notes: List.generate(
+            5,
+            (i) => makeTestNote(
+              title: 'Note $i',
+              from: DateTime(2026, 2, 22, 8 + i, 0),
+            ),
+          ),
+        );
+
+        final exported = provider.exportToString(
+          diaryDays: [dayWithNotes, dayWithoutNotes, dayWithManyNotes],
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+
+        expect(imported.data, hasLength(3));
+        expect(imported.data[0].notes, hasLength(2));
+        expect(imported.data[1].notes, isEmpty);
+        expect(imported.data[2].notes, hasLength(5));
+      });
+
+      test('file-based export and import round-trip with notes', () async {
+        final file = File('${tempDir.path}/notes_roundtrip.json');
+        final notes = [
+          makeTestNote(
+            title: 'Important Meeting',
+            description: 'Discuss project roadmap',
+            from: DateTime(2026, 2, 20, 10, 0),
+          ),
+        ];
+        final diaryDays = [makeTestDiaryDay(day: DateTime(2026, 2, 20), notes: notes)];
+
+        await provider.exportWithMetadata(
+          diaryDays: diaryDays,
+          file: file,
+          username: 'test_user',
+          encrypted: false,
+        );
+
+        // Import into a fresh provider
+        final importProvider = FileDbProvider();
+        final metadata = await importProvider.import(file);
+
+        expect(metadata, isNotNull);
+        expect(metadata!.encrypted, false);
+        expect(metadata.username, 'test_user');
+        expect(importProvider.state, hasLength(1));
+        expect(importProvider.state.first.notes, hasLength(1));
+        expect(importProvider.state.first.notes.first.title, 'Important Meeting');
+      });
+
+      test('encrypted round-trip preserves notes', () async {
+        const password = 'securePassword123';
+        final hashResult = PasswordAuthService.hashPassword(password);
+        final salt = hashResult['salt']!;
+        final file = File('${tempDir.path}/encrypted_notes.json');
+
+        final notes = [
+          makeTestNote(title: 'Secret Note', from: DateTime(2026, 2, 20, 9, 0)),
+        ];
+        final diaryDays = [makeTestDiaryDay(day: DateTime(2026, 2, 20), notes: notes)];
+
+        await provider.exportWithMetadata(
+          diaryDays: diaryDays,
+          file: file,
+          username: 'secure_user',
+          salt: salt,
+          encrypted: true,
+          password: password,
+        );
+
+        final importProvider = FileDbProvider();
+        final metadata =
+            await importProvider.import(file, password: password);
+
+        expect(metadata!.encrypted, true);
+        expect(importProvider.state, hasLength(1));
+        expect(importProvider.state.first.notes, hasLength(1));
+        expect(importProvider.state.first.notes.first.title, 'Secret Note');
+      });
+
+      test('import populates provider state for downstream use', () async {
+        final file = File('${tempDir.path}/state_test.json');
+        final diaryDays = [
+          makeTestDiaryDay(
+            day: DateTime(2026, 2, 20),
+            notes: [
+              makeTestNote(title: 'Work', from: DateTime(2026, 2, 20, 9, 0)),
+            ],
+          ),
+          makeTestDiaryDay(
+            day: DateTime(2026, 2, 21),
+            notes: [
+              makeTestNote(title: 'Play', from: DateTime(2026, 2, 21, 15, 0)),
+            ],
+          ),
+        ];
+
+        await provider.exportWithMetadata(
+          diaryDays: diaryDays,
+          file: file,
+          encrypted: false,
+        );
+
+        final importProvider = FileDbProvider();
+        await importProvider.import(file);
+
+        // State should be directly usable
+        expect(importProvider.state, hasLength(2));
+        final allNotes = importProvider.state.expand((d) => d.notes).toList();
+        expect(allNotes, hasLength(2));
+        expect(allNotes.map((n) => n.title), containsAll(['Work', 'Play']));
+      });
+    });
+
+    group('cross-feature data integrity', () {
+      test('note categories are preserved through export/import', () {
+        final diaryDay = makeTestDiaryDay(
+          day: DateTime(2026, 2, 20),
+          notes: [
+            makeTestNote(
+              title: 'Work Task',
+              from: DateTime(2026, 2, 20, 9, 0),
+              category: workCategory,
+            ),
+            makeTestNote(
+              title: 'Lunch',
+              from: DateTime(2026, 2, 20, 12, 0),
+              category: foodCategory,
+            ),
+          ],
+        );
+
+        final exported = provider.exportToString(
+          diaryDays: [diaryDay],
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+        final importedNotes = imported.data.first.notes;
+
+        expect(importedNotes[0].noteCategory.title, 'Work');
+        expect(importedNotes[1].noteCategory.title, 'Food');
+      });
+
+      test('all 4 DayRating types survive round-trip', () {
+        final diaryDay = makeTestDiaryDay(
+          day: DateTime(2026, 2, 20),
+          ratings: [
+            DayRating(dayRating: DayRatings.social, score: 5),
+            DayRating(dayRating: DayRatings.productivity, score: 2),
+            DayRating(dayRating: DayRatings.sport, score: 4),
+            DayRating(dayRating: DayRatings.food, score: 3),
+          ],
+        );
+
+        final exported = provider.exportToString(
+          diaryDays: [diaryDay],
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+        final ratings = imported.data.first.ratings;
+
+        expect(ratings, hasLength(4));
+        expect(ratings.firstWhere((r) => r.dayRating == DayRatings.social).score, 5);
+        expect(ratings.firstWhere((r) => r.dayRating == DayRatings.productivity).score, 2);
+        expect(ratings.firstWhere((r) => r.dayRating == DayRatings.sport).score, 4);
+        expect(ratings.firstWhere((r) => r.dayRating == DayRatings.food).score, 3);
+      });
+
+      test('enhanced day rating survives export/import round-trip', () {
+        final enhanced = EnhancedDayRating(
+          date: DateTime(2026, 2, 20),
+          quickMood: MoodPosition(
+            valence: 0.7,
+            arousal: 0.5,
+            timestamp: DateTime(2026, 2, 20, 8, 0),
+          ),
+          wellbeing: const WellbeingRating(
+            mood: 4,
+            energy: 3,
+            connection: 5,
+            purpose: 4,
+            achievement: 3,
+            engagement: 4,
+          ),
+          emotions: const [],
+          context: ContextualFactors.empty(),
+        );
+
+        final diaryDay = makeTestDiaryDay(
+          day: DateTime(2026, 2, 20),
+          enhancedRating: enhanced,
+        );
+
+        final exported = provider.exportToString(
+          diaryDays: [diaryDay],
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+        final importedRating = imported.data.first.enhancedRating;
+
+        expect(importedRating, isNotNull);
+        expect(importedRating!.quickMood!.valence, closeTo(0.7, 0.001));
+        expect(importedRating.quickMood!.arousal, closeTo(0.5, 0.001));
+        expect(importedRating.wellbeing.mood, 4);
+        expect(importedRating.wellbeing.connection, 5);
+      });
+
+      test('empty data exports and imports cleanly', () {
+        final exported = provider.exportToString(
+          diaryDays: [],
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+        expect(imported.data, isEmpty);
+      });
+
+      test('large dataset round-trip (30 days with notes)', () {
+        final diaryDays = List.generate(30, (i) {
+          final day = dateAt(i);
+          return makeTestDiaryDay(
+            day: day,
+            notes: List.generate(
+              3,
+              (j) => makeTestNote(
+                title: 'Note $j on day $i',
+                from: DateTime(day.year, day.month, day.day, 8 + j, 0),
+              ),
+            ),
+          );
+        });
+
+        final exported = provider.exportToString(
+          diaryDays: diaryDays,
+          encrypted: false,
+        );
+
+        final imported = ExportData.fromJson(exported);
+
+        expect(imported.data, hasLength(30));
+        // Spot-check
+        expect(imported.data.first.notes, hasLength(3));
+        expect(imported.data.last.notes, hasLength(3));
+        expect(imported.data[15].notes.first.title, 'Note 0 on day 15');
+      });
+    });
+  });
+}

--- a/test/integration/note_search_workflow_test.dart
+++ b/test/integration/note_search_workflow_test.dart
@@ -1,0 +1,233 @@
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/domain/providers/category_local_db_provider.dart';
+import 'package:day_tracker/features/notes/domain/providers/note_local_db_provider.dart';
+import 'package:day_tracker/features/notes/domain/providers/note_search_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/integration_test_fixtures.dart';
+import '../helpers/widget_test_helpers.dart';
+
+void main() {
+  setUpAll(() => initTestSettingsContainer());
+
+  group('Note Search Workflow', () {
+    // Shared test data
+    final testNotes = [
+      makeTestNote(
+        id: 'n1',
+        title: 'Morning Standup',
+        description: 'Daily team sync',
+        from: DateTime(2026, 2, 20, 9, 0),
+        category: workCategory,
+      ),
+      makeTestNote(
+        id: 'n2',
+        title: 'Lunch Break',
+        description: 'Pasta at Italian place',
+        from: DateTime(2026, 2, 20, 12, 0),
+        category: foodCategory,
+      ),
+      makeTestNote(
+        id: 'n3',
+        title: 'Code Review',
+        description: 'PR #42 review session',
+        from: DateTime(2026, 2, 21, 14, 0),
+        category: workCategory,
+      ),
+      makeTestNote(
+        id: 'n4',
+        title: 'Dinner',
+        description: 'Cooked pasta at home',
+        from: DateTime(2026, 2, 21, 19, 0),
+        category: foodCategory,
+      ),
+    ];
+
+    ProviderContainer createContainer({List<Note>? notes}) {
+      return ProviderContainer(overrides: [
+        notesLocalDataProvider.overrideWith(
+          (_) => TestDbRepository<Note>(
+            tableName: Note.tableName,
+            columns: Note.columns,
+            fromMap: Note.fromDbMap,
+            initialData: notes ?? testNotes,
+          ),
+        ),
+        categoryLocalDataProvider
+            .overrideWith((_) => TestCategoryProvider(integrationTestCategories)),
+      ]);
+    }
+
+    group('full provider chain: add note -> search -> filter', () {
+      test('notes added to provider appear in filteredNotesProvider', () async {
+        final container = createContainer(notes: []);
+        addTearDown(container.dispose);
+
+        // Initially empty
+        expect(container.read(filteredNotesProvider), isEmpty);
+
+        // Add notes one by one
+        final notifier = container.read(notesLocalDataProvider.notifier);
+        await notifier.addElement(testNotes[0]);
+        expect(container.read(filteredNotesProvider), hasLength(1));
+
+        await notifier.addElement(testNotes[1]);
+        expect(container.read(filteredNotesProvider), hasLength(2));
+      });
+
+      test('setting search query filters results in real-time', () {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        // All notes present initially
+        expect(container.read(filteredNotesProvider), hasLength(4));
+
+        // Search for "pasta" — should match Lunch Break + Dinner
+        container.read(noteSearchProvider.notifier).setQuery('pasta');
+        final results = container.read(filteredNotesProvider);
+
+        expect(results, hasLength(2));
+        expect(results.map((n) => n.title), containsAll(['Lunch Break', 'Dinner']));
+      });
+
+      test('category filter narrows results', () {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        container
+            .read(noteSearchProvider.notifier)
+            .setCategoryFilter(workCategory);
+        final results = container.read(filteredNotesProvider);
+
+        expect(results, hasLength(2));
+        expect(
+          results.every((n) => n.noteCategory.title == 'Work'),
+          isTrue,
+        );
+      });
+
+      test('combined category + text search narrows results further', () {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        final searchNotifier = container.read(noteSearchProvider.notifier);
+        searchNotifier.setCategoryFilter(workCategory);
+        searchNotifier.setQuery('standup');
+
+        final results = container.read(filteredNotesProvider);
+
+        expect(results, hasLength(1));
+        expect(results.first.title, 'Morning Standup');
+      });
+
+      test('date range filter works through provider chain', () {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        // Filter to Feb 20 only
+        container.read(noteSearchProvider.notifier).setDateRange(
+              DateTime(2026, 2, 20),
+              DateTime(2026, 2, 20),
+            );
+
+        final results = container.read(filteredNotesProvider);
+
+        expect(results, hasLength(2));
+        expect(
+          results.map((n) => n.title),
+          containsAll(['Morning Standup', 'Lunch Break']),
+        );
+      });
+
+      test('clearAll resets to showing all notes', () {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        // Apply filters
+        final searchNotifier = container.read(noteSearchProvider.notifier);
+        searchNotifier.setQuery('standup');
+        searchNotifier.setCategoryFilter(workCategory);
+        expect(container.read(filteredNotesProvider), hasLength(1));
+
+        // Clear all
+        searchNotifier.clearAll();
+        expect(container.read(filteredNotesProvider), hasLength(4));
+      });
+
+      test('adding a note while filter is active updates filtered results',
+          () async {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        // Set a filter
+        container.read(noteSearchProvider.notifier).setQuery('meeting');
+        expect(container.read(filteredNotesProvider), isEmpty);
+
+        // Add a matching note
+        await container.read(notesLocalDataProvider.notifier).addElement(
+              makeTestNote(
+                title: 'Team Meeting',
+                description: 'Monthly review',
+                from: DateTime(2026, 2, 22, 10, 0),
+                category: workCategory,
+              ),
+            );
+
+        // filteredNotesProvider should now include the new note
+        final results = container.read(filteredNotesProvider);
+        expect(results, hasLength(1));
+        expect(results.first.title, 'Team Meeting');
+      });
+
+      test('deleting a note updates filtered results', () async {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        container.read(noteSearchProvider.notifier).setQuery('standup');
+        expect(container.read(filteredNotesProvider), hasLength(1));
+
+        // Delete the matching note
+        await container
+            .read(notesLocalDataProvider.notifier)
+            .deleteElement(testNotes[0]);
+
+        expect(container.read(filteredNotesProvider), isEmpty);
+      });
+    });
+
+    group('favorites filter through provider chain', () {
+      test('toggling favorites filter shows only favorite notes', () {
+        final favNotes = [
+          makeTestNote(
+            id: 'f1',
+            title: 'Fav Note',
+            description: 'Favorite',
+            from: DateTime(2026, 2, 20, 9, 0),
+            isFavorite: true,
+          ),
+          makeTestNote(
+            id: 'f2',
+            title: 'Regular Note',
+            description: 'Not favorite',
+            from: DateTime(2026, 2, 20, 10, 0),
+            isFavorite: false,
+          ),
+        ];
+
+        final container = createContainer(notes: favNotes);
+        addTearDown(container.dispose);
+
+        // All notes initially
+        expect(container.read(filteredNotesProvider), hasLength(2));
+
+        // Toggle favorites
+        container.read(noteSearchProvider.notifier).toggleFavoritesOnly();
+        final results = container.read(filteredNotesProvider);
+
+        expect(results, hasLength(1));
+        expect(results.first.title, 'Fav Note');
+      });
+    });
+  });
+}

--- a/test/integration/settings_persistence_workflow_test.dart
+++ b/test/integration/settings_persistence_workflow_test.dart
@@ -1,0 +1,163 @@
+import 'package:day_tracker/core/provider/locale_provider.dart';
+import 'package:day_tracker/core/provider/theme_provider.dart';
+import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/theme/themes.dart';
+import 'package:day_tracker/features/authentication/data/models/user_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+void main() {
+  group('Settings Persistence Workflow', () {
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      // Prevent GoogleFonts from fetching fonts over the network in tests
+      GoogleFonts.config.allowRuntimeFetching = false;
+      dotenv.testLoad(mergeWith: {'PROJECT_NAME': 'test_project'});
+    });
+
+    setUp(() {
+      settingsContainer = SettingsContainer();
+      settingsContainer.activeUserSettings = UserSettings.fromEmpty();
+    });
+
+    group('theme persistence across provider recreation', () {
+      testWidgets('seed color change survives ThemeProvider recreation',
+          (tester) async {
+        // Session 1: change theme color
+        final provider1 = ThemeProvider();
+        provider1.updateThemeFromSeedColor(Colors.blue);
+
+        // Persist to settings (normally done by ThemeSettingsWidget)
+        settingsContainer.activeUserSettings.themeSeedColor = Colors.blue;
+
+        // Session 2: recreate provider (simulates app restart)
+        final provider2 = ThemeProvider();
+
+        expect(provider2.seedColor, equals(Colors.blue));
+      });
+
+      testWidgets('dark mode toggle survives ThemeProvider recreation',
+          (tester) async {
+        // Session 1: enable dark mode
+        final provider1 = ThemeProvider();
+        expect(provider1.state.brightness, Brightness.light);
+
+        provider1.toggleDarkMode(true);
+        expect(provider1.state.brightness, Brightness.dark);
+
+        // Persist to settings
+        settingsContainer.activeUserSettings.darkThemeMode = true;
+
+        // Session 2: recreate
+        final provider2 = ThemeProvider();
+
+        expect(provider2.state.brightness, Brightness.dark);
+      });
+
+      testWidgets('default seed color is used when no settings persisted',
+          (tester) async {
+        final provider = ThemeProvider();
+
+        expect(provider.seedColor, equals(defaultSeedColor));
+      });
+    });
+
+    group('locale persistence across provider recreation', () {
+      test('locale change persists to settingsContainer automatically', () {
+        final provider = LocaleProvider();
+
+        provider.setLocale(const Locale('de'));
+
+        // LocaleProvider auto-persists to settingsContainer
+        expect(
+          settingsContainer.activeUserSettings.languageCode,
+          equals('de'),
+        );
+      });
+
+      test('locale survives LocaleProvider recreation', () {
+        // Session 1: change to German
+        final provider1 = LocaleProvider();
+        provider1.setLocale(const Locale('de'));
+
+        // Session 2: recreate (reads from settingsContainer)
+        final provider2 = LocaleProvider();
+
+        expect(provider2.state, equals(const Locale('de')));
+      });
+    });
+
+    group('combined settings workflow', () {
+      testWidgets('theme + locale + dark mode all persist across restart',
+          (tester) async {
+        // Session 1: change multiple settings
+        final theme1 = ThemeProvider();
+        final locale1 = LocaleProvider();
+
+        theme1.updateThemeFromSeedColor(Colors.deepPurple);
+        theme1.toggleDarkMode(true);
+        locale1.setLocale(const Locale('de'));
+
+        // Persist theme (locale auto-persists)
+        settingsContainer.activeUserSettings.themeSeedColor = Colors.deepPurple;
+        settingsContainer.activeUserSettings.darkThemeMode = true;
+
+        // Session 2: recreate all providers
+        final theme2 = ThemeProvider();
+        final locale2 = LocaleProvider();
+
+        expect(theme2.seedColor, equals(Colors.deepPurple));
+        expect(theme2.state.brightness, Brightness.dark);
+        expect(locale2.state, equals(const Locale('de')));
+      });
+
+      testWidgets('different users have independent settings',
+          (tester) async {
+        // Set up user A
+        settingsContainer.activeUserSettings.themeSeedColor = Colors.blue;
+        settingsContainer.activeUserSettings.darkThemeMode = true;
+        settingsContainer.activeUserSettings.languageCode = 'de';
+
+        final themeA = ThemeProvider();
+        expect(themeA.seedColor, equals(Colors.blue));
+        expect(themeA.state.brightness, Brightness.dark);
+
+        // Switch to user B (fresh defaults)
+        settingsContainer.activeUserSettings = UserSettings.fromEmpty();
+
+        final themeB = ThemeProvider();
+        final localeB = LocaleProvider();
+
+        expect(themeB.seedColor, equals(defaultSeedColor));
+        expect(themeB.state.brightness, Brightness.light);
+        expect(localeB.state, equals(const Locale('en')));
+      });
+
+      testWidgets(
+          'ThemeProvider does not auto-persist but LocaleProvider does',
+          (tester) async {
+        final theme = ThemeProvider();
+        final locale = LocaleProvider();
+
+        // ThemeProvider updates state but NOT settingsContainer
+        theme.updateThemeFromSeedColor(Colors.red);
+        expect(theme.seedColor, equals(Colors.red));
+        // settingsContainer still has default
+        expect(
+          settingsContainer.activeUserSettings.themeSeedColor,
+          equals(defaultSeedColor),
+        );
+
+        // LocaleProvider updates BOTH state and settingsContainer
+        locale.setLocale(const Locale('de'));
+        expect(locale.state, equals(const Locale('de')));
+        expect(
+          settingsContainer.activeUserSettings.languageCode,
+          equals('de'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Introduced integration tests for the diary entry workflow, verifying provider interactions and data persistence.
- Added tests for the note search workflow, ensuring real-time filtering and category-based searches function correctly.
- Updated test coverage documentation to reflect the addition of new integration tests and improved overall test coverage metrics.
- Enhanced CI workflow to include the execution of new integration tests during the build process.