### PR TITLE
refactor: migrate settings management to Riverpod

### DIFF
--- a/lib/core/database/db_provider_factory.dart
+++ b/lib/core/database/db_provider_factory.dart
@@ -2,6 +2,7 @@ import 'package:day_tracker/core/database/db_column.dart';
 import 'package:day_tracker/core/database/db_entity.dart';
 import 'package:day_tracker/core/database/db_migration.dart';
 import 'package:day_tracker/core/database/db_repository.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Creates a fully wired Riverpod [StateNotifierProvider] for [DbRepository].
@@ -27,10 +28,12 @@ StateNotifierProvider<DbRepository<T>, List<T>>
   List<String> additionalSql = const [],
 }) {
   return StateNotifierProvider<DbRepository<T>, List<T>>((ref) {
+    final appDocPath = ref.read(settingsProvider).applicationDocumentsPath;
     return DbRepository<T>(
       tableName: tableName,
       columns: columns,
       fromMap: fromMap,
+      applicationDocumentsPath: appDocPath,
       migrations: migrations,
       additionalSql: additionalSql,
     );

--- a/lib/core/database/db_repository.dart
+++ b/lib/core/database/db_repository.dart
@@ -4,7 +4,6 @@ import 'package:day_tracker/core/database/db_column.dart';
 import 'package:day_tracker/core/database/db_entity.dart';
 import 'package:day_tracker/core/database/db_migration.dart';
 import 'package:day_tracker/core/log/logger_instance.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
 import 'package:day_tracker/features/authentication/data/models/user_data.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -32,6 +31,7 @@ class DbRepository<T extends DbEntity> extends StateNotifier<List<T>> {
   final T Function(Map<String, dynamic> map) fromMap;
   final List<DbMigration> migrations;
   final List<String> additionalSql;
+  final String applicationDocumentsPath;
 
   Database? _database;
   bool _databaseRead = false;
@@ -44,10 +44,11 @@ class DbRepository<T extends DbEntity> extends StateNotifier<List<T>> {
     required this.tableName,
     required this.columns,
     required this.fromMap,
+    required this.applicationDocumentsPath,
     this.migrations = const [],
     this.additionalSql = const [],
   })  : _dbFile = File(
-            '${settingsContainer.applicationDocumentsPath}/empty.db'),
+            '$applicationDocumentsPath/empty.db'),
         super([]) {
     primaryKey = columns.firstWhere((c) => c.isPrimaryKey).name;
     _init();
@@ -110,7 +111,7 @@ class DbRepository<T extends DbEntity> extends StateNotifier<List<T>> {
     if (userData.username.isEmpty) return;
 
     _dbFile = File(
-      '${settingsContainer.applicationDocumentsPath}/${userData.userId}.db',
+      '$applicationDocumentsPath/${userData.userId}.db',
     );
     if (!_dbFile.existsSync()) {
       LogWrapper.logger.t('creates dbFile ${_dbFile.path}');

--- a/lib/core/log/logger_instance.dart
+++ b/lib/core/log/logger_instance.dart
@@ -8,6 +8,7 @@ class LogWrapper {
   LogWrapper();
 
   static Future<File> createLogfile() async {
+    // ignore: deprecated_member_use
     var logDir =
         Directory('${settingsContainer.applicationExternalDocumentsPath}/Logs');
     await logDir.create(recursive: true);

--- a/lib/core/provider/locale_provider.dart
+++ b/lib/core/provider/locale_provider.dart
@@ -1,17 +1,20 @@
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class LocaleProvider extends StateNotifier<Locale> {
-  LocaleProvider()
-      : super(Locale(settingsContainer.activeUserSettings.languageCode));
+  final SettingsContainer _settings;
+
+  LocaleProvider(this._settings)
+      : super(Locale(_settings.activeUserSettings.languageCode));
 
   void setLocale(Locale locale) {
     state = locale;
-    settingsContainer.activeUserSettings.languageCode = locale.languageCode;
+    _settings.activeUserSettings.languageCode = locale.languageCode;
   }
 }
 
 final localeProvider = StateNotifierProvider<LocaleProvider, Locale>(
-  (ref) => LocaleProvider(),
+  (ref) => LocaleProvider(ref.read(settingsProvider)),
 );

--- a/lib/core/provider/theme_provider.dart
+++ b/lib/core/provider/theme_provider.dart
@@ -1,18 +1,21 @@
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/theme/themes.dart';
 import 'package:day_tracker/core/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ThemeProvider extends StateNotifier<ThemeData> {
-  ThemeProvider()
-      : super(buildAppTheme(
-          seedColor: settingsContainer.activeUserSettings.themeSeedColor,
-          isDark: settingsContainer.activeUserSettings.darkThemeMode,
+  ThemeProvider(SettingsContainer settings)
+      : _seedColor = settings.activeUserSettings.themeSeedColor,
+        darkMode = settings.activeUserSettings.darkThemeMode,
+        super(buildAppTheme(
+          seedColor: settings.activeUserSettings.themeSeedColor,
+          isDark: settings.activeUserSettings.darkThemeMode,
         ));
-  bool darkMode = false;
-  Color _seedColor = settingsContainer.activeUserSettings.themeSeedColor;
+  bool darkMode;
+  Color _seedColor;
 
   void updateThemeFromSeedColor(Color newThemeColor) {
     LogWrapper.logger
@@ -35,5 +38,5 @@ class ThemeProvider extends StateNotifier<ThemeData> {
 }
 
 final themeProvider = StateNotifierProvider<ThemeProvider, ThemeData>(
-  (ref) => ThemeProvider(),
+  (ref) => ThemeProvider(ref.read(settingsProvider)),
 );

--- a/lib/core/services/backup_scheduler.dart
+++ b/lib/core/services/backup_scheduler.dart
@@ -53,6 +53,7 @@ class BackupScheduler {
     required List<Habit> habits,
     required List<HabitEntry> habitEntries,
   }) async {
+    // ignore: deprecated_member_use
     final settings = settingsContainer.activeUserSettings.backupSettings;
     if (!settings.enabled) return null;
     if (!settings.isBackupOverdue) {
@@ -100,6 +101,7 @@ class BackupScheduler {
   /// Returns updated metadata with cloudSynced flag on success.
   /// For cloudOnly destination, deletes the local file after successful upload.
   Future<BackupMetadata> _tryCloudUpload(BackupMetadata metadata) async {
+    // ignore: deprecated_member_use
     final settings = settingsContainer.activeUserSettings.backupSettings;
     if (!settings.isCloudEnabled) return metadata;
 

--- a/lib/core/services/backup_service.dart
+++ b/lib/core/services/backup_service.dart
@@ -23,7 +23,9 @@ class BackupService {
 
   /// Get the backup directory path, creating it if needed
   Future<Directory> getBackupDirectory() async {
+    // ignore: deprecated_member_use
     final customPath = settingsContainer.activeUserSettings.backupSettings.backupDirectoryPath;
+    // ignore: deprecated_member_use
     final basePath = customPath ?? settingsContainer.applicationDocumentsPath;
     final dir = Directory('$basePath/$_backupSubDir');
     if (!await dir.exists()) {
@@ -35,6 +37,7 @@ class BackupService {
   /// Create an [AesEncryptor] from the current user's credentials.
   /// Returns null if no clear password is available (user not logged in).
   AesEncryptor? _createEncryptor() {
+    // ignore: deprecated_member_use
     final userData = settingsContainer.activeUserSettings.savedUserData;
     final clearPassword = userData.clearPassword;
     final salt = userData.salt;
@@ -127,8 +130,10 @@ class BackupService {
       await _saveMetadataToIndex(metadata);
 
       // Update last backup timestamp in settings
+      // ignore: deprecated_member_use
       settingsContainer.activeUserSettings.backupSettings.lastBackupTimestamp =
           now.toIso8601String();
+      // ignore: deprecated_member_use
       await settingsContainer.saveSettings();
 
       LogWrapper.logger.i(
@@ -259,6 +264,7 @@ class BackupService {
 
   /// Remove old backups exceeding the max count setting
   Future<void> pruneOldBackups() async {
+    // ignore: deprecated_member_use
     final maxBackups = settingsContainer.activeUserSettings.backupSettings.maxBackups;
     final index = await _loadMetadataIndex();
 

--- a/lib/core/services/cloud_backup_service.dart
+++ b/lib/core/services/cloud_backup_service.dart
@@ -34,6 +34,7 @@ class CloudBackupService {
   /// Ensure Supabase is initialized and authenticated.
   /// Returns true if ready, false if not configured or auth fails.
   Future<bool> _ensureAuthenticated() async {
+    // ignore: deprecated_member_use
     final settings = settingsContainer.activeUserSettings.supabaseSettings;
     if (settings.supabaseUrl.isEmpty ||
         settings.supabaseAnonKey.isEmpty ||

--- a/lib/core/services/image_storage_service.dart
+++ b/lib/core/services/image_storage_service.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 
 class ImageStorageService {
   Directory _imagesDir() {
+    // ignore: deprecated_member_use
     final basePath = settingsContainer.applicationDocumentsPath;
     return Directory(p.join(basePath, 'images'));
   }

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -258,6 +258,7 @@ void _callbackDispatcher() {
 
       switch (task) {
         case 'diary_reminder_check':
+          // ignore: deprecated_member_use
           final settings = settingsContainer.activeUserSettings.notificationSettings;
           if (!settings.smartRemindersEnabled) {
             return Future.value(true);

--- a/lib/core/settings/settings_container.dart
+++ b/lib/core/settings/settings_container.dart
@@ -111,4 +111,7 @@ class SettingsContainer {
   }
 }
 
+@Deprecated('Use ref.read(settingsProvider) instead. '
+    'Kept only for services that cannot access Riverpod (e.g. background isolates).')
+// ignore: deprecated_member_use_from_same_package
 var settingsContainer = SettingsContainer();

--- a/lib/core/settings/settings_provider.dart
+++ b/lib/core/settings/settings_provider.dart
@@ -1,0 +1,25 @@
+import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the [SettingsContainer] instance via Riverpod.
+///
+/// Overridden in `main()` with the loaded settings, and in tests
+/// with a fresh [SettingsContainer] for isolation.
+final settingsProvider = Provider<SettingsContainer>((ref) {
+  // ignore: deprecated_member_use_from_same_package
+  return settingsContainer;
+});
+
+/// Helper that wraps [SettingsContainer.saveSettings] for use via `ref`.
+///
+/// Usage: `ref.read(settingsNotifierProvider).saveSettings()`
+class SettingsNotifier {
+  final SettingsContainer _container;
+  SettingsNotifier(this._container);
+
+  Future<void> saveSettings() => _container.saveSettings();
+}
+
+final settingsNotifierProvider = Provider<SettingsNotifier>((ref) {
+  return SettingsNotifier(ref.read(settingsProvider));
+});

--- a/lib/features/app/presentation/pages/backup_history_page.dart
+++ b/lib/features/app/presentation/pages/backup_history_page.dart
@@ -4,7 +4,7 @@ import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/services/backup_service.dart';
 import 'package:day_tracker/core/services/backup_scheduler.dart';
 import 'package:day_tracker/core/services/cloud_backup_service.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
 import 'package:day_tracker/features/day_rating/domain/providers/diary_day_local_db_provider.dart';
 import 'package:day_tracker/features/habits/data/models/habit.dart';
@@ -487,7 +487,7 @@ class _BackupHistoryPageState extends ConsumerState<BackupHistoryPage> {
   // -- Cloud sync helpers --
 
   bool get _isCloudSyncEnabled =>
-      settingsContainer.activeUserSettings.backupSettings.isCloudEnabled;
+      ref.read(settingsProvider).activeUserSettings.backupSettings.isCloudEnabled;
 
   Future<void> _uploadToCloud(
     BackupMetadata backup,

--- a/lib/features/app/presentation/pages/main_page.dart
+++ b/lib/features/app/presentation/pages/main_page.dart
@@ -9,7 +9,7 @@ import 'package:day_tracker/core/services/backup_scheduler.dart';
 import 'package:day_tracker/core/services/onboarding_service.dart';
 import 'package:day_tracker/core/navigation/drawer_index_provider.dart';
 import 'package:day_tracker/core/navigation/drawer_item_builder.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/utils/debug_auto_login.dart';
 import 'package:day_tracker/features/authentication/data/models/user_data.dart';
 import 'package:day_tracker/features/authentication/domain/providers/user_data_provider.dart';
@@ -117,7 +117,7 @@ class _MainPageState extends ConsumerState<MainPage> {
           return const AuthUserDataPage();
         } else if (userData.username.isNotEmpty && !userData.isLoggedIn) {
           // Check if biometric is enabled for this user
-          final biometricEnabled = settingsContainer
+          final biometricEnabled = ref.read(settingsProvider)
               .activeUserSettings.biometricSettings.isEnabled;
           final skipBiometric = ref.watch(skipBiometricProvider);
           if (biometricEnabled && !skipBiometric) {
@@ -460,7 +460,7 @@ class _MainPageState extends ConsumerState<MainPage> {
   Future<AppExitResponse> _handleExitRequest() async {
     LogWrapper.logger.i('leaves app');
     await _decryptDatabase(_userData, UserData.fromEmpty());
-    settingsContainer.saveSettings();
+    ref.read(settingsNotifierProvider).saveSettings();
     return AppExitResponse.exit;
   }
 
@@ -476,7 +476,7 @@ class _MainPageState extends ConsumerState<MainPage> {
   void _handleOnResume() {
     LogWrapper.logger.d('resumes app');
     final biometricSettings =
-        settingsContainer.activeUserSettings.biometricSettings;
+        ref.read(settingsProvider).activeUserSettings.biometricSettings;
     if (biometricSettings.isEnabled &&
         biometricSettings.requireOnResume &&
         _backgroundTimestamp != null &&

--- a/lib/features/app/presentation/widgets/backup_settings_widget.dart
+++ b/lib/features/app/presentation/widgets/backup_settings_widget.dart
@@ -2,7 +2,7 @@ import 'package:day_tracker/core/backup/backup_metadata.dart';
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/services/backup_scheduler.dart';
 import 'package:day_tracker/core/settings/backup_settings.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/app/presentation/pages/backup_history_page.dart';
 import 'package:day_tracker/features/day_rating/domain/providers/diary_day_local_db_provider.dart';
 import 'package:day_tracker/features/habits/domain/providers/habit_providers.dart';
@@ -33,7 +33,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
   @override
   void initState() {
     super.initState();
-    final settings = settingsContainer.activeUserSettings.backupSettings;
+    final settings = ref.read(settingsProvider).activeUserSettings.backupSettings;
     _backupEnabled = settings.enabled;
     _frequency = settings.frequency;
     _preferredTime = settings.preferredTime;
@@ -42,10 +42,10 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
     _destination = settings.destination;
   }
 
-  void _autoSave() => settingsContainer.saveSettings().ignore();
+  void _autoSave() => ref.read(settingsNotifierProvider).saveSettings().ignore();
 
   bool get _isSupabaseConfigured {
-    final s = settingsContainer.activeUserSettings.supabaseSettings;
+    final s = ref.read(settingsProvider).activeUserSettings.supabaseSettings;
     return s.supabaseUrl.isNotEmpty &&
         s.supabaseAnonKey.isNotEmpty &&
         s.email.isNotEmpty &&
@@ -56,12 +56,12 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final backupSettings = settingsContainer.activeUserSettings.backupSettings;
+    final backupSettings = ref.read(settingsProvider).activeUserSettings.backupSettings;
     final isOverdue = backupSettings.isBackupOverdue;
     final lastBackup = backupSettings.lastBackupDateTime;
 
     final customPath = backupSettings.backupDirectoryPath;
-    final defaultPath = settingsContainer.applicationDocumentsPath;
+    final defaultPath = ref.read(settingsProvider).applicationDocumentsPath;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -131,7 +131,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
                   onSelectionChanged: (selected) {
                     setState(() {
                       _frequency = selected.first;
-                      settingsContainer.activeUserSettings.backupSettings
+                      ref.read(settingsProvider).activeUserSettings.backupSettings
                           .frequency = _frequency;
                     });
                     _autoSave();
@@ -191,11 +191,11 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
                   onSelectionChanged: (selected) {
                     setState(() {
                       _destination = selected.first;
-                      settingsContainer.activeUserSettings.backupSettings
+                      ref.read(settingsProvider).activeUserSettings.backupSettings
                           .destination = _destination;
                     });
                     BackupScheduler().updateSchedule(
-                      settingsContainer.activeUserSettings.backupSettings,
+                      ref.read(settingsProvider).activeUserSettings.backupSettings,
                     );
                     _autoSave();
                   },
@@ -213,7 +213,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
                     onChanged: (value) {
                       setState(() {
                         _wifiOnly = value;
-                        settingsContainer.activeUserSettings.backupSettings
+                        ref.read(settingsProvider).activeUserSettings.backupSettings
                             .wifiOnly = value;
                       });
                       _autoSave();
@@ -240,7 +240,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
                         onChanged: (value) {
                           setState(() {
                             _maxBackups = value.round();
-                            settingsContainer
+                            ref.read(settingsProvider)
                                 .activeUserSettings.backupSettings
                                 .maxBackups = _maxBackups;
                           });
@@ -284,7 +284,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
                       child: TextButton.icon(
                         onPressed: () {
                           setState(() {
-                            settingsContainer
+                            ref.read(settingsProvider)
                                 .activeUserSettings.backupSettings
                                 .backupDirectoryPath = null;
                           });
@@ -352,12 +352,12 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
   void _onBackupToggled(bool value) {
     setState(() {
       _backupEnabled = value;
-      settingsContainer.activeUserSettings.backupSettings.enabled = value;
+      ref.read(settingsProvider).activeUserSettings.backupSettings.enabled = value;
     });
     _autoSave();
 
     BackupScheduler().updateSchedule(
-      settingsContainer.activeUserSettings.backupSettings,
+      ref.read(settingsProvider).activeUserSettings.backupSettings,
     );
 
     if (!value) {
@@ -371,7 +371,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
     final selectedDirectory = await FilePicker.platform.getDirectoryPath();
     if (selectedDirectory != null && mounted) {
       setState(() {
-        settingsContainer.activeUserSettings.backupSettings
+        ref.read(settingsProvider).activeUserSettings.backupSettings
             .backupDirectoryPath = selectedDirectory;
       });
       _autoSave();
@@ -389,7 +389,7 @@ class _BackupSettingsWidgetState extends ConsumerState<BackupSettingsWidget> {
     if (picked != null && picked != _preferredTime) {
       setState(() {
         _preferredTime = picked;
-        settingsContainer.activeUserSettings.backupSettings.preferredTime =
+        ref.read(settingsProvider).activeUserSettings.backupSettings.preferredTime =
             picked;
       });
       _autoSave();

--- a/lib/features/app/presentation/widgets/biometric_settings_widget.dart
+++ b/lib/features/app/presentation/widgets/biometric_settings_widget.dart
@@ -1,6 +1,6 @@
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/services/biometric_service.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/authentication/domain/providers/biometric_provider.dart';
 import 'package:day_tracker/features/authentication/domain/providers/user_data_provider.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
@@ -26,13 +26,13 @@ class _BiometricSettingsWidgetState
   @override
   void initState() {
     super.initState();
-    final settings = settingsContainer.activeUserSettings.biometricSettings;
+    final settings = ref.read(settingsProvider).activeUserSettings.biometricSettings;
     _biometricEnabled = settings.isEnabled;
     _requireOnResume = settings.requireOnResume;
     _lockTimeoutMinutes = settings.lockTimeoutMinutes;
   }
 
-  void _autoSave() => settingsContainer.saveSettings().ignore();
+  void _autoSave() => ref.read(settingsNotifierProvider).saveSettings().ignore();
 
   @override
   Widget build(BuildContext context) {
@@ -124,7 +124,7 @@ class _BiometricSettingsWidgetState
                   onChanged: (value) {
                     setState(() {
                       _requireOnResume = value;
-                      settingsContainer.activeUserSettings.biometricSettings
+                      ref.read(settingsProvider).activeUserSettings.biometricSettings
                           .requireOnResume = value;
                     });
                     _autoSave();
@@ -171,7 +171,7 @@ class _BiometricSettingsWidgetState
                         if (value != null) {
                           setState(() {
                             _lockTimeoutMinutes = value;
-                            settingsContainer
+                            ref.read(settingsProvider)
                                 .activeUserSettings.biometricSettings
                                 .lockTimeoutMinutes = value;
                           });
@@ -228,7 +228,7 @@ class _BiometricSettingsWidgetState
 
     setState(() {
       _biometricEnabled = value;
-      settingsContainer.activeUserSettings.biometricSettings.isEnabled = value;
+      ref.read(settingsProvider).activeUserSettings.biometricSettings.isEnabled = value;
     });
     _autoSave();
   }

--- a/lib/features/app/presentation/widgets/language_settings_widget.dart
+++ b/lib/features/app/presentation/widgets/language_settings_widget.dart
@@ -1,5 +1,5 @@
 import 'package:day_tracker/core/provider/locale_provider.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:day_tracker/l10n/app_localizations.dart';
@@ -61,7 +61,7 @@ class LanguageSettingsWidget extends ConsumerWidget {
                   ref
                       .read(localeProvider.notifier)
                       .setLocale(Locale(newValue));
-                  settingsContainer.saveSettings().ignore();
+                  ref.read(settingsNotifierProvider).saveSettings().ignore();
                 }
               },
             ),

--- a/lib/features/app/presentation/widgets/notification_settings_widget.dart
+++ b/lib/features/app/presentation/widgets/notification_settings_widget.dart
@@ -1,6 +1,6 @@
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/services/notification_service.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:day_tracker/l10n/app_localizations.dart';
@@ -27,14 +27,14 @@ class _NotificationSettingsWidgetState
   void initState() {
     super.initState();
     final settings =
-        settingsContainer.activeUserSettings.notificationSettings;
+        ref.read(settingsProvider).activeUserSettings.notificationSettings;
     _notificationsEnabled = settings.enabled;
     _smartRemindersEnabled = settings.smartRemindersEnabled;
     _streakWarningsEnabled = settings.streakWarningsEnabled;
     _reminderTime = settings.reminderTime;
   }
 
-  void _autoSave() => settingsContainer.saveSettings().ignore();
+  void _autoSave() => ref.read(settingsNotifierProvider).saveSettings().ignore();
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +70,7 @@ class _NotificationSettingsWidgetState
               onChanged: (value) {
                 setState(() {
                   _smartRemindersEnabled = value;
-                  settingsContainer.activeUserSettings.notificationSettings
+                  ref.read(settingsProvider).activeUserSettings.notificationSettings
                       .smartRemindersEnabled = value;
                 });
                 _autoSave();
@@ -86,7 +86,7 @@ class _NotificationSettingsWidgetState
               onChanged: (value) {
                 setState(() {
                   _streakWarningsEnabled = value;
-                  settingsContainer.activeUserSettings.notificationSettings
+                  ref.read(settingsProvider).activeUserSettings.notificationSettings
                       .streakWarningsEnabled = value;
                 });
                 _autoSave();
@@ -113,13 +113,13 @@ class _NotificationSettingsWidgetState
 
     setState(() {
       _notificationsEnabled = value;
-      settingsContainer.activeUserSettings.notificationSettings.enabled = value;
+      ref.read(settingsProvider).activeUserSettings.notificationSettings.enabled = value;
     });
     _autoSave();
 
     if (value) {
       await _notificationService.scheduleDailyReminder(
-        settingsContainer.activeUserSettings.notificationSettings,
+        ref.read(settingsProvider).activeUserSettings.notificationSettings,
       );
       LogWrapper.logger.i('Notifications enabled and scheduled');
     } else {
@@ -139,14 +139,14 @@ class _NotificationSettingsWidgetState
     if (picked != null && picked != _reminderTime) {
       setState(() {
         _reminderTime = picked;
-        settingsContainer.activeUserSettings.notificationSettings.reminderTime =
+        ref.read(settingsProvider).activeUserSettings.notificationSettings.reminderTime =
             picked;
       });
       _autoSave();
 
       if (_notificationsEnabled) {
         await _notificationService.scheduleDailyReminder(
-          settingsContainer.activeUserSettings.notificationSettings,
+          ref.read(settingsProvider).activeUserSettings.notificationSettings,
         );
       }
     }

--- a/lib/features/app/presentation/widgets/supabase_settings_widget.dart
+++ b/lib/features/app/presentation/widgets/supabase_settings_widget.dart
@@ -1,4 +1,4 @@
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
 import 'package:day_tracker/features/synchronization/domain/providers/supabase_provider.dart';
 import 'package:day_tracker/features/synchronization/data/repositories/supabase_api.dart';
@@ -28,7 +28,7 @@ class _SupabaseSettingsWidgetState
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final settings = settingsContainer.activeUserSettings.supabaseSettings;
+      final settings = ref.read(settingsProvider).activeUserSettings.supabaseSettings;
       _urlController.text = settings.supabaseUrl;
       _anonKeyController.text = settings.supabaseAnonKey;
       _emailController.text = settings.email;
@@ -86,9 +86,10 @@ class _SupabaseSettingsWidgetState
               ref
                   .read(supabaseSettingsProvider.notifier)
                   .updateUrl(value);
-              settingsContainer.activeUserSettings.supabaseSettings =
-                  settingsContainer.activeUserSettings.supabaseSettings
+              ref.read(settingsProvider).activeUserSettings.supabaseSettings =
+                  ref.read(settingsProvider).activeUserSettings.supabaseSettings
                       .copyWith(supabaseUrl: value);
+              ref.read(settingsNotifierProvider).saveSettings().ignore();
             },
           ),
         ),
@@ -116,9 +117,10 @@ class _SupabaseSettingsWidgetState
               ref
                   .read(supabaseSettingsProvider.notifier)
                   .updateAnonKey(value);
-              settingsContainer.activeUserSettings.supabaseSettings =
-                  settingsContainer.activeUserSettings.supabaseSettings
+              ref.read(settingsProvider).activeUserSettings.supabaseSettings =
+                  ref.read(settingsProvider).activeUserSettings.supabaseSettings
                       .copyWith(supabaseAnonKey: value);
+              ref.read(settingsNotifierProvider).saveSettings().ignore();
             },
           ),
         ),
@@ -135,9 +137,10 @@ class _SupabaseSettingsWidgetState
               ref
                   .read(supabaseSettingsProvider.notifier)
                   .updateEmail(value);
-              settingsContainer.activeUserSettings.supabaseSettings =
-                  settingsContainer.activeUserSettings.supabaseSettings
+              ref.read(settingsProvider).activeUserSettings.supabaseSettings =
+                  ref.read(settingsProvider).activeUserSettings.supabaseSettings
                       .copyWith(email: value);
+              ref.read(settingsNotifierProvider).saveSettings().ignore();
             },
           ),
         ),
@@ -165,9 +168,10 @@ class _SupabaseSettingsWidgetState
               ref
                   .read(supabaseSettingsProvider.notifier)
                   .updatePassword(value);
-              settingsContainer.activeUserSettings.supabaseSettings =
-                  settingsContainer.activeUserSettings.supabaseSettings
+              ref.read(settingsProvider).activeUserSettings.supabaseSettings =
+                  ref.read(settingsProvider).activeUserSettings.supabaseSettings
                       .copyWith(password: value);
+              ref.read(settingsNotifierProvider).saveSettings().ignore();
             },
           ),
         ),

--- a/lib/features/app/presentation/widgets/theme_settings_widget.dart
+++ b/lib/features/app/presentation/widgets/theme_settings_widget.dart
@@ -1,5 +1,5 @@
 import 'package:day_tracker/core/provider/theme_provider.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
 import 'package:flutter/material.dart';
@@ -15,11 +15,18 @@ class ThemeSettingsWidget extends ConsumerStatefulWidget {
 }
 
 class _ThemeSettingsWidgetState extends ConsumerState<ThemeSettingsWidget> {
-  Color _dialogPickerColor =
-      settingsContainer.activeUserSettings.themeSeedColor;
-  var _darkModeSwitch = settingsContainer.activeUserSettings.darkThemeMode;
+  late Color _dialogPickerColor;
+  late bool _darkModeSwitch;
 
-  void _autoSave() => settingsContainer.saveSettings().ignore();
+  @override
+  void initState() {
+    super.initState();
+    final settings = ref.read(settingsProvider);
+    _dialogPickerColor = settings.activeUserSettings.themeSeedColor;
+    _darkModeSwitch = settings.activeUserSettings.darkThemeMode;
+  }
+
+  void _autoSave() => ref.read(settingsNotifierProvider).saveSettings().ignore();
 
   @override
   Widget build(BuildContext context) {
@@ -114,14 +121,14 @@ class _ThemeSettingsWidgetState extends ConsumerState<ThemeSettingsWidget> {
   void _onColorPickerAcceptedClicked(Color color) {
     setState(() => _dialogPickerColor = color);
     ref.read(themeProvider.notifier).updateThemeFromSeedColor(color);
-    settingsContainer.activeUserSettings.themeSeedColor = color;
+    ref.read(settingsProvider).activeUserSettings.themeSeedColor = color;
     _autoSave();
   }
 
   void _onSwitchDarkModeClicked(bool value) {
     setState(() => _darkModeSwitch = value);
     ref.read(themeProvider.notifier).toggleDarkMode(_darkModeSwitch);
-    settingsContainer.activeUserSettings.darkThemeMode = value;
+    ref.read(settingsProvider).activeUserSettings.darkThemeMode = value;
     _autoSave();
   }
 }

--- a/lib/features/authentication/domain/providers/biometric_provider.dart
+++ b/lib/features/authentication/domain/providers/biometric_provider.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: public_member_api_docs
 import 'package:day_tracker/core/services/biometric_service.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Whether biometric hardware is available on this device
@@ -15,7 +15,7 @@ final biometricStatusProvider = FutureProvider<BiometricStatus>((ref) async {
 
 /// Whether the current user has biometric login enabled
 final biometricEnabledProvider = Provider<bool>((ref) {
-  return settingsContainer.activeUserSettings.biometricSettings.isEnabled;
+  return ref.read(settingsProvider).activeUserSettings.biometricSettings.isEnabled;
 });
 
 /// Temporary flag to skip biometric and show password page instead.

--- a/lib/features/authentication/domain/providers/user_data_provider.dart
+++ b/lib/features/authentication/domain/providers/user_data_provider.dart
@@ -1,15 +1,18 @@
 import 'package:day_tracker/core/authentication/password_auth_service.dart';
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/utils/debug_auto_login.dart';
 import 'package:day_tracker/features/authentication/data/models/user_data.dart';
 import 'package:day_tracker/features/authentication/data/models/user_settings.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class UserDataProvider extends StateNotifier<UserData> {
-  UserDataProvider()
-      : super(settingsContainer.lastLoggedInUsername.isNotEmpty
-            ? settingsContainer.getUserSettings().savedUserData
+  final SettingsContainer _settings;
+
+  UserDataProvider(this._settings)
+      : super(_settings.lastLoggedInUsername.isNotEmpty
+            ? _settings.getUserSettings().savedUserData
             : UserData.fromEmpty());
 
   void createUser(UserData userData) {
@@ -18,7 +21,7 @@ class UserDataProvider extends StateNotifier<UserData> {
     if (userData.username != _demoUsername) {
       _removeDemoUserIfExists();
     }
-    bool userExists = settingsContainer.checkIfUserExists(userData.username);
+    bool userExists = _settings.checkIfUserExists(userData.username);
     assert(!userExists, '${userData.username} already exists in the database');
 
     // Store original clear password
@@ -39,11 +42,11 @@ class UserDataProvider extends StateNotifier<UserData> {
     UserSettings newUserSettings = UserSettings.fromEmpty();
     newUserSettings.savedUserData = savedUser;
 
-    settingsContainer.userSettings.add(newUserSettings);
-    settingsContainer.lastLoggedInUsername = userData.username;
-    settingsContainer.activeUserSettings = newUserSettings;
-    settingsContainer.activeUserSettings.savedUserData.clearPassword = originalPassword;
-    settingsContainer.saveSettings();
+    _settings.userSettings.add(newUserSettings);
+    _settings.lastLoggedInUsername = userData.username;
+    _settings.activeUserSettings = newUserSettings;
+    _settings.activeUserSettings.savedUserData.clearPassword = originalPassword;
+    _settings.saveSettings();
 
     // Create a new UserData for state with clearPassword
     UserData sessionUser = UserData(
@@ -60,10 +63,10 @@ class UserDataProvider extends StateNotifier<UserData> {
   }
 
   bool login(String username, String password) {
-    bool userExists = settingsContainer.checkIfUserExists(username);
+    bool userExists = _settings.checkIfUserExists(username);
     assert(userExists, '$username doesnt exist in the database');
 
-    var savedUserData = settingsContainer.userSettings
+    var savedUserData = _settings.userSettings
         .firstWhere(
             (userSetting) => userSetting.savedUserData.username == username)
         .savedUserData;
@@ -89,10 +92,10 @@ class UserDataProvider extends StateNotifier<UserData> {
     );
 
     state = stateUserData;
-    settingsContainer.lastLoggedInUsername = stateUserData.username;
-    settingsContainer.activeUserSettings = settingsContainer.getUserSettings();
-    settingsContainer.activeUserSettings.savedUserData.clearPassword = password;
-    settingsContainer.saveSettings();
+    _settings.lastLoggedInUsername = stateUserData.username;
+    _settings.activeUserSettings = _settings.getUserSettings();
+    _settings.activeUserSettings.savedUserData.clearPassword = password;
+    _settings.saveSettings();
     LogWrapper.logger.i('logged in as ${state.username}');
     return true;
   }
@@ -100,9 +103,9 @@ class UserDataProvider extends StateNotifier<UserData> {
   void updateUser(UserData userData) {
     LogWrapper.logger.i('update user ${userData.username}');
     var oldUsername =
-        settingsContainer.activeUserSettings.savedUserData.username;
+        _settings.activeUserSettings.savedUserData.username;
 
-    var savedUserData = settingsContainer.userSettings
+    var savedUserData = _settings.userSettings
         .firstWhere(
             (userSetting) =>
                 userSetting.savedUserData.username == oldUsername)
@@ -129,16 +132,16 @@ class UserDataProvider extends StateNotifier<UserData> {
     savedUserData.email = userData.email;
 
     // update saved user
-    settingsContainer.activeUserSettings.savedUserData = savedUserData;
-    settingsContainer.activeUserSettings.savedUserData.clearPassword = originalPassword;
-    settingsContainer.lastLoggedInUsername = userData.username;
-    var existingUserIndex = settingsContainer.userSettings.indexWhere(
-        (userSetting) => userSetting == settingsContainer.activeUserSettings);
+    _settings.activeUserSettings.savedUserData = savedUserData;
+    _settings.activeUserSettings.savedUserData.clearPassword = originalPassword;
+    _settings.lastLoggedInUsername = userData.username;
+    var existingUserIndex = _settings.userSettings.indexWhere(
+        (userSetting) => userSetting == _settings.activeUserSettings);
     if (existingUserIndex != -1) {
-      settingsContainer.userSettings[existingUserIndex] =
-          settingsContainer.activeUserSettings;
+      _settings.userSettings[existingUserIndex] =
+          _settings.activeUserSettings;
     }
-    settingsContainer.saveSettings();
+    _settings.saveSettings();
 
     // update state user with clear password
     UserData updatedStateUser = UserData(
@@ -172,18 +175,18 @@ class UserDataProvider extends StateNotifier<UserData> {
   void logout() {
     LogWrapper.logger.i('logout from user ${state.username}');
     UserData emptyUser = UserData.fromEmpty();
-    var userSettings = settingsContainer.userSettings;
+    var userSettings = _settings.userSettings;
     var emptyUserSettings = userSettings.firstWhere(
       (userSetting) => userSetting.savedUserData.username == emptyUser.username,
       orElse: () => UserSettings.fromEmpty(),
     );
-    if (!settingsContainer
+    if (!_settings
         .checkIfUserExists(emptyUserSettings.savedUserData.username)) {
       createUser(UserData.fromEmpty());
     } else {
-      settingsContainer.activeUserSettings =
+      _settings.activeUserSettings =
           emptyUserSettings; // 0 is always empty user
-      settingsContainer.lastLoggedInUsername = '';
+      _settings.lastLoggedInUsername = '';
     }
     state = emptyUser;
   }
@@ -194,7 +197,7 @@ class UserDataProvider extends StateNotifier<UserData> {
   /// onboarding path.  The account has an empty password so no authentication
   /// dialog is shown.
   void createDemoUser() {
-    if (!settingsContainer.checkIfUserExists(_demoUsername)) {
+    if (!_settings.checkIfUserExists(_demoUsername)) {
       createUser(UserData(username: _demoUsername, clearPassword: ''));
     } else {
       login(_demoUsername, '');
@@ -204,7 +207,7 @@ class UserDataProvider extends StateNotifier<UserData> {
   /// Removes the demo guest account from settings if it exists.
   /// Called automatically at the start of [createUser] for real accounts.
   void _removeDemoUserIfExists() {
-    settingsContainer.userSettings.removeWhere(
+    _settings.userSettings.removeWhere(
       (s) => s.savedUserData.username == _demoUsername,
     );
     LogWrapper.logger.d('Removed demo user account if present');
@@ -222,7 +225,7 @@ class UserDataProvider extends StateNotifier<UserData> {
     LogWrapper.logger.i('Debug auto-login: attempting login as $username');
 
     // Create user if doesn't exist yet
-    if (!settingsContainer.checkIfUserExists(username)) {
+    if (!_settings.checkIfUserExists(username)) {
       LogWrapper.logger.i('Debug auto-login: creating test user $username');
       createUser(UserData(
         username: username,
@@ -253,12 +256,12 @@ class UserDataProvider extends StateNotifier<UserData> {
 }
 
 final userDataProvider = StateNotifierProvider<UserDataProvider, UserData>(
-  (ref) => UserDataProvider(),
+  (ref) => UserDataProvider(ref.read(settingsProvider)),
 );
 
 final userDataSettingsProvider = Provider<UserSettings>((ref) {
   final userData = ref.watch(userDataProvider);
-  var userSettings = settingsContainer.userSettings;
+  var userSettings = ref.read(settingsProvider).userSettings;
   return userSettings.firstWhere(
       (userSetting) => userSetting.savedUserData.username == userData.username);
 });

--- a/lib/features/authentication/presentation/pages/auth_user_data_page.dart
+++ b/lib/features/authentication/presentation/pages/auth_user_data_page.dart
@@ -1,4 +1,4 @@
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/authentication/data/models/user_data.dart';
 import 'package:day_tracker/features/authentication/domain/providers/user_data_provider.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
@@ -16,13 +16,19 @@ class AuthUserDataPage extends ConsumerStatefulWidget {
 
 class _AuthUserDataPageState extends ConsumerState<AuthUserDataPage> {
   final _formKey = GlobalKey<FormState>();
-  var _isLogin = settingsContainer.userSettings.isNotEmpty;
+  late bool _isLogin;
   var _isAuthenticating = false;
   var _isRemoteAccount = false;
   var _isPasswordVisible = false;
 
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _isLogin = ref.read(settingsProvider).userSettings.isNotEmpty;
+  }
   final _emailController = TextEditingController();
 
   //? build --------------------------------------------------------------------

--- a/lib/features/note_templates/domain/providers/default_templates_provider.dart
+++ b/lib/features/note_templates/domain/providers/default_templates_provider.dart
@@ -1,4 +1,4 @@
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/note_templates/data/models/description_section.dart';
 import 'package:day_tracker/features/note_templates/data/models/note_template.dart';
 import 'package:day_tracker/features/notes/data/models/note_category.dart';
@@ -8,7 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final defaultTemplatesProvider = Provider<List<NoteTemplate>>((ref) {
   final categories = ref.watch(categoryLocalDataProvider);
-  final languageCode = settingsContainer.activeUserSettings.languageCode;
+  final languageCode = ref.read(settingsProvider).activeUserSettings.languageCode;
 
   // Helper to find category by title, or use first available
   NoteCategory getCategoryByTitle(String title) {

--- a/lib/features/note_templates/domain/providers/note_template_local_db_provider.dart
+++ b/lib/features/note_templates/domain/providers/note_template_local_db_provider.dart
@@ -1,16 +1,18 @@
 import 'package:day_tracker/core/database/db_repository.dart';
 import 'package:day_tracker/core/log/logger_instance.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/note_templates/data/models/note_template.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// NoteTemplateLocalDataProvider — subclasses DbRepository for custom
 /// default template initialization logic.
 class NoteTemplateLocalDataProvider extends DbRepository<NoteTemplate> {
-  NoteTemplateLocalDataProvider()
+  NoteTemplateLocalDataProvider({required String applicationDocumentsPath})
       : super(
           tableName: NoteTemplate.tableName,
           columns: NoteTemplate.columns,
           fromMap: NoteTemplate.fromDbMap,
+          applicationDocumentsPath: applicationDocumentsPath,
           migrations: NoteTemplate.migrations,
         );
 
@@ -36,7 +38,8 @@ class NoteTemplateLocalDataProvider extends DbRepository<NoteTemplate> {
 }
 
 final noteTemplateLocalDataProvider = StateNotifierProvider<NoteTemplateLocalDataProvider, List<NoteTemplate>>((ref) {
-  return NoteTemplateLocalDataProvider();
+  final appDocPath = ref.read(settingsProvider).applicationDocumentsPath;
+  return NoteTemplateLocalDataProvider(applicationDocumentsPath: appDocPath);
 });
 
 // Provider for the currently selected template

--- a/lib/features/notes/domain/providers/category_local_db_provider.dart
+++ b/lib/features/notes/domain/providers/category_local_db_provider.dart
@@ -1,6 +1,7 @@
 import 'package:day_tracker/core/database/db_repository.dart';
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/notes/data/models/note.dart';
 import 'package:day_tracker/features/notes/data/models/note_category.dart';
 import 'package:flutter/material.dart';
@@ -9,11 +10,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// CategoryLocalDataProvider — subclasses DbRepository for custom logic
 /// (default category initialization, name validation).
 class CategoryLocalDataProvider extends DbRepository<NoteCategory> {
-  CategoryLocalDataProvider()
+  final SettingsContainer _settings;
+
+  CategoryLocalDataProvider(this._settings)
       : super(
           tableName: NoteCategory.tableName,
           columns: NoteCategory.columns,
           fromMap: NoteCategory.fromDbMap,
+          applicationDocumentsPath: _settings.applicationDocumentsPath,
           migrations: NoteCategory.migrations,
         );
 
@@ -29,7 +33,7 @@ class CategoryLocalDataProvider extends DbRepository<NoteCategory> {
   }
 
   Future<void> _addDefaultCategories() async {
-    final languageCode = settingsContainer.activeUserSettings.languageCode;
+    final languageCode = _settings.activeUserSettings.languageCode;
     final categoryNames = _getLocalizedCategoryNames(languageCode);
 
     final defaultCategories = [
@@ -138,7 +142,7 @@ class CategoryLocalDataProvider extends DbRepository<NoteCategory> {
 
 final categoryLocalDataProvider =
     StateNotifierProvider<CategoryLocalDataProvider, List<NoteCategory>>((ref) {
-  return CategoryLocalDataProvider();
+  return CategoryLocalDataProvider(ref.read(settingsProvider));
 });
 
 //-----------------------------------------------------------------------------------------------------------------------------------

--- a/lib/features/notes/domain/providers/note_attachments_provider.dart
+++ b/lib/features/notes/domain/providers/note_attachments_provider.dart
@@ -2,16 +2,18 @@ import 'dart:io';
 
 import 'package:day_tracker/core/database/db_repository.dart';
 import 'package:day_tracker/core/services/image_storage_service.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/notes/data/models/note_attachment.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// NoteAttachmentsProvider — subclasses DbRepository for custom image logic.
 class NoteAttachmentsProvider extends DbRepository<NoteAttachment> {
-  NoteAttachmentsProvider()
+  NoteAttachmentsProvider({required String applicationDocumentsPath})
       : super(
           tableName: NoteAttachment.tableName,
           columns: NoteAttachment.columns,
           fromMap: NoteAttachment.fromDbMap,
+          applicationDocumentsPath: applicationDocumentsPath,
           migrations: NoteAttachment.migrations,
         );
 
@@ -42,5 +44,6 @@ class NoteAttachmentsProvider extends DbRepository<NoteAttachment> {
 
 final noteAttachmentsProvider =
     StateNotifierProvider<NoteAttachmentsProvider, List<NoteAttachment>>((ref) {
-  return NoteAttachmentsProvider();
+  final appDocPath = ref.read(settingsProvider).applicationDocumentsPath;
+  return NoteAttachmentsProvider(applicationDocumentsPath: appDocPath);
 });

--- a/lib/features/onboarding/presentation/pages/setup_wizard_page.dart
+++ b/lib/features/onboarding/presentation/pages/setup_wizard_page.dart
@@ -1,6 +1,6 @@
 import 'package:day_tracker/core/provider/locale_provider.dart';
 import 'package:day_tracker/core/provider/theme_provider.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
 import 'package:day_tracker/features/authentication/presentation/pages/auth_user_data_page.dart';
 import 'package:day_tracker/l10n/app_localizations.dart';
@@ -52,7 +52,7 @@ class _SetupWizardPageState extends ConsumerState<SetupWizardPage> {
   }
 
   void _onDone() {
-    settingsContainer.saveSettings();
+    ref.read(settingsNotifierProvider).saveSettings();
     Navigator.of(context).pushReplacement(
       AppPageRoute(builder: (_) => const AuthUserDataPage()),
     );
@@ -186,7 +186,7 @@ class _ThemeStepPage extends ConsumerWidget {
                   isSelected: !isDark,
                   onTap: () {
                     ref.read(themeProvider.notifier).toggleDarkMode(false);
-                    settingsContainer.activeUserSettings.darkThemeMode = false;
+                    ref.read(settingsProvider).activeUserSettings.darkThemeMode = false;
                   },
                 ),
               ),
@@ -198,7 +198,7 @@ class _ThemeStepPage extends ConsumerWidget {
                   isSelected: isDark,
                   onTap: () {
                     ref.read(themeProvider.notifier).toggleDarkMode(true);
-                    settingsContainer.activeUserSettings.darkThemeMode = true;
+                    ref.read(settingsProvider).activeUserSettings.darkThemeMode = true;
                   },
                 ),
               ),

--- a/lib/features/synchronization/domain/providers/pdf_export_provider.dart
+++ b/lib/features/synchronization/domain/providers/pdf_export_provider.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:day_tracker/features/synchronization/data/services/pdf_report_generator.dart';
 import 'package:day_tracker/features/day_rating/domain/providers/diary_day_local_db_provider.dart';
 import 'package:day_tracker/features/notes/domain/providers/note_local_db_provider.dart';
-import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 
 enum DateRangeType { week, month, currentMonth, custom, all }
 
@@ -152,7 +152,7 @@ final pdfExportProvider = FutureProvider.family<Uint8List, DateRange>(
   (ref, dateRange) async {
     final diaryDays = ref.read(diaryDayFullDataProvider);
     final notes = ref.read(notesLocalDataProvider);
-    final username = settingsContainer.activeUserSettings.savedUserData.username;
+    final username = ref.read(settingsProvider).activeUserSettings.savedUserData.username;
 
     final generator = PdfReportGenerator(
       diaryDays: diaryDays,

--- a/lib/features/synchronization/domain/providers/supabase_provider.dart
+++ b/lib/features/synchronization/domain/providers/supabase_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:day_tracker/core/log/logger_instance.dart';
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/authentication/domain/providers/user_data_provider.dart';
 import 'package:day_tracker/features/day_rating/domain/providers/diary_day_local_db_provider.dart';
 import 'package:day_tracker/features/notes/domain/providers/note_local_db_provider.dart';
@@ -19,12 +20,13 @@ final supabaseApiProvider = Provider<SupabaseApi>((ref) {
 // Supabase settings provider
 final supabaseSettingsProvider = StateNotifierProvider<SupabaseSettingsNotifier, SupabaseSettings>((ref) {
   LogWrapper.logger.d('Creating new SupabaseSettingsNotifier');
-  return SupabaseSettingsNotifier();
+  final settings = ref.read(settingsProvider);
+  return SupabaseSettingsNotifier(settings);
 });
 
 class SupabaseSettingsNotifier extends StateNotifier<SupabaseSettings> {
-  SupabaseSettingsNotifier() : super(settingsContainer.activeUserSettings.supabaseSettings) {
-    LogWrapper.logger.i('Initialized SupabaseSettingsNotifier with settings for user: ${settingsContainer.activeUserSettings.savedUserData.username}');
+  SupabaseSettingsNotifier(SettingsContainer settings) : super(settings.activeUserSettings.supabaseSettings) {
+    LogWrapper.logger.i('Initialized SupabaseSettingsNotifier with settings for user: ${settings.activeUserSettings.savedUserData.username}');
   }
 
   void updateSettings(SupabaseSettings settings) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:day_tracker/core/provider/theme_provider.dart';
 import 'package:day_tracker/core/services/backup_scheduler.dart';
 import 'package:day_tracker/core/services/notification_service.dart';
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/core/utils/platform_utils.dart';
 import 'package:day_tracker/features/app/presentation/pages/main_page.dart';
 import 'package:flutter/material.dart';
@@ -30,7 +31,10 @@ void main() async {
     }
 
     LogWrapper.logger.d('Reading application settings');
-    await settingsContainer.readSettings();
+    final settings = SettingsContainer();
+    await settings.readSettings();
+    // ignore: deprecated_member_use
+    settingsContainer = settings; // keep for services that can't use ref
 
     if (activePlatform.platform == ActivePlatform.windows || activePlatform.platform == ActivePlatform.linux) {
       LogWrapper.logger.d('Initializing FFI for desktop platform');
@@ -39,7 +43,7 @@ void main() async {
     }
 
     //* init logger
-    bool debugging = settingsContainer.debugMode;
+    bool debugging = settings.debugMode;
     LogWrapper.logger = Logger(
       level: debugging ? Level.trace : Level.info,
       output: ConsoleOutput(),
@@ -52,14 +56,14 @@ void main() async {
     await NotificationService().initialize();
 
     // Schedule notifications if enabled
-    final notificationSettings = settingsContainer.activeUserSettings.notificationSettings;
+    final notificationSettings = settings.activeUserSettings.notificationSettings;
     if (notificationSettings.enabled) {
       LogWrapper.logger.d('Scheduling notifications (enabled in settings)');
       await NotificationService().scheduleDailyReminder(notificationSettings);
     }
 
     //* init backup scheduler
-    final backupSettings = settingsContainer.activeUserSettings.backupSettings;
+    final backupSettings = settings.activeUserSettings.backupSettings;
     if (backupSettings.enabled) {
       LogWrapper.logger.d('Updating backup schedule (enabled in settings)');
       await BackupScheduler().updateSchedule(backupSettings);
@@ -68,7 +72,12 @@ void main() async {
     LogWrapper.logger.i('Initialization complete, starting application');
     //* run
     runApp(
-      const ProviderScope(child: MyApp()),
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWithValue(settings),
+        ],
+        child: const MyApp(),
+      ),
     );
   } catch (e) {
     LogWrapper.logger.e('Failed to initialize application: $e');
@@ -97,7 +106,7 @@ class _MyAppState extends ConsumerState<MyApp> {
     LogWrapper.logger.d('Building MyApp');
     return MaterialApp(
       theme: ref.watch(themeProvider),
-      debugShowCheckedModeBanner: settingsContainer.debugMode,
+      debugShowCheckedModeBanner: ref.watch(settingsProvider).debugMode,
       home: const MainPage(
         title: 'Simple Diary',
       ),

--- a/test/core/provider/locale_provider_test.dart
+++ b/test/core/provider/locale_provider_test.dart
@@ -26,7 +26,7 @@ void main() {
       // Set language to German in settings
       settingsContainer.activeUserSettings.languageCode = 'de';
 
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       expect(provider.state, equals(const Locale('de')));
     });
@@ -34,13 +34,13 @@ void main() {
     test('initial locale defaults to English', () {
       settingsContainer.activeUserSettings.languageCode = 'en';
 
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       expect(provider.state, equals(const Locale('en')));
     });
 
     test('setLocale updates state', () {
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       provider.setLocale(const Locale('de'));
 
@@ -48,7 +48,7 @@ void main() {
     });
 
     test('setLocale persists to settings', () {
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       provider.setLocale(const Locale('de'));
 
@@ -58,7 +58,7 @@ void main() {
     test('setLocale to English', () {
       // Start with German
       settingsContainer.activeUserSettings.languageCode = 'de';
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       // Switch to English
       provider.setLocale(const Locale('en'));
@@ -68,7 +68,7 @@ void main() {
     });
 
     test('state updates trigger listeners', () {
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
       var listenerCalled = false;
       Locale? capturedLocale;
 
@@ -84,7 +84,7 @@ void main() {
     });
 
     test('languageCode property matches locale', () {
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       provider.setLocale(const Locale('de'));
       expect(provider.state.languageCode, equals('de'));
@@ -94,7 +94,7 @@ void main() {
     });
 
     test('handles unsupported locale gracefully', () {
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       // Try to set an unsupported locale (should still work, but app might fallback)
       provider.setLocale(const Locale('fr'));
@@ -104,7 +104,7 @@ void main() {
     });
 
     test('multiple locale changes preserve state', () {
-      final provider = LocaleProvider();
+      final provider = LocaleProvider(settingsContainer);
 
       provider.setLocale(const Locale('de'));
       expect(provider.state.languageCode, equals('de'));

--- a/test/features/authentication/providers/debug_auto_login_provider_test.dart
+++ b/test/features/authentication/providers/debug_auto_login_provider_test.dart
@@ -44,7 +44,7 @@ void main() {
         'DEBUG_EMAIL': 'test@test.com',
       });
 
-      final provider = UserDataProvider();
+      final provider = UserDataProvider(settingsContainer);
       provider.debugAutoLogin();
 
       expect(provider.debugState.isLoggedIn, true);
@@ -63,14 +63,14 @@ void main() {
       });
 
       // First create the user
-      final provider = UserDataProvider();
+      final provider = UserDataProvider(settingsContainer);
       provider.debugAutoLogin();
       expect(provider.debugState.isLoggedIn, true);
 
       // Create a new provider instance (simulates app restart)
       // The user now exists in settingsContainer
       settingsContainer.lastLoggedInUsername = 'testuser';
-      final provider2 = UserDataProvider();
+      final provider2 = UserDataProvider(settingsContainer);
       // State loaded from settings but not logged in yet
       expect(provider2.debugState.isLoggedIn, false);
 
@@ -89,7 +89,7 @@ void main() {
         'DEBUG_PASSWORD': 'testpass123',
       });
 
-      final provider = UserDataProvider();
+      final provider = UserDataProvider(settingsContainer);
       provider.debugAutoLogin();
 
       expect(provider.debugState.isLoggedIn, false);
@@ -103,7 +103,7 @@ void main() {
         'DEBUG_PASSWORD': 'testpass123',
       });
 
-      final provider = UserDataProvider();
+      final provider = UserDataProvider(settingsContainer);
       provider.debugAutoLogin();
 
       expect(provider.debugState.isLoggedIn, false);
@@ -117,7 +117,7 @@ void main() {
         'DEBUG_PASSWORD': 'short',
       });
 
-      final provider = UserDataProvider();
+      final provider = UserDataProvider(settingsContainer);
       provider.debugAutoLogin();
 
       expect(provider.debugState.isLoggedIn, false);
@@ -131,7 +131,7 @@ void main() {
         'DEBUG_PASSWORD': 'testpass123',
       });
 
-      final provider = UserDataProvider();
+      final provider = UserDataProvider(settingsContainer);
       provider.debugAutoLogin();
 
       expect(provider.debugState.isLoggedIn, false);

--- a/test/helpers/widget_test_helpers.dart
+++ b/test/helpers/widget_test_helpers.dart
@@ -1,6 +1,7 @@
 import 'package:day_tracker/core/database/db_entity.dart';
 import 'package:day_tracker/core/database/db_repository.dart';
 import 'package:day_tracker/core/settings/settings_container.dart';
+import 'package:day_tracker/core/settings/settings_provider.dart';
 import 'package:day_tracker/features/dashboard/data/models/dashboard_stats.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:day_tracker/features/dashboard/data/models/insight.dart';
@@ -39,8 +40,10 @@ void initTestSettingsContainer() {
   // dotenv must be loaded before SettingsContainer is constructed,
   // because its constructor reads dotenv.env['PROJECT_NAME'].
   dotenv.testLoad(fileInput: "PROJECT_NAME=day_tracker");
+  // ignore: deprecated_member_use
   settingsContainer = SettingsContainer();
   // Set a valid path so DbRepository constructors don't break
+  // ignore: deprecated_member_use
   settingsContainer.applicationDocumentsPath = '/tmp/test_diary';
 }
 
@@ -55,6 +58,7 @@ class TestDbRepository<T extends DbEntity> extends DbRepository<T> {
     required super.columns,
     required super.fromMap,
     super.migrations,
+    super.applicationDocumentsPath = '/tmp/test_diary',
     List<T>? initialData,
   }) {
     if (initialData != null) state = initialData;
@@ -106,7 +110,8 @@ class TestCategoryProvider extends CategoryLocalDataProvider {
   final List<NoteCategory> _initialCategories;
 
   TestCategoryProvider([List<NoteCategory>? initial])
-      : _initialCategories = initial ?? [] {
+      // ignore: deprecated_member_use
+      : _initialCategories = initial ?? [], super(settingsContainer) {
     state = _initialCategories;
   }
 
@@ -143,7 +148,7 @@ class TestCategoryProvider extends CategoryLocalDataProvider {
 
 /// Test-safe NoteAttachmentsProvider (skips SQLite + image storage).
 class TestAttachmentProvider extends NoteAttachmentsProvider {
-  TestAttachmentProvider();
+  TestAttachmentProvider() : super(applicationDocumentsPath: '/tmp/test_diary');
 
   @override
   Future<void> initDatabase() async {}
@@ -166,7 +171,7 @@ class TestAttachmentProvider extends NoteAttachmentsProvider {
 
 /// Test-safe NoteTemplateLocalDataProvider (skips SQLite).
 class TestNoteTemplateProvider extends NoteTemplateLocalDataProvider {
-  TestNoteTemplateProvider();
+  TestNoteTemplateProvider() : super(applicationDocumentsPath: '/tmp/test_diary');
 
   @override
   Future<void> initDatabase() async {}
@@ -230,6 +235,10 @@ List<Override> createTestOverrides({
   final stats = dashboardStats ?? testDashboardStats;
 
   return [
+    // Settings provider (must be first — other providers read from it)
+    // ignore: deprecated_member_use
+    settingsProvider.overrideWithValue(settingsContainer),
+
     // Core providers
     categoryLocalDataProvider.overrideWith((_) => TestCategoryProvider(cats)),
     notesLocalDataProvider.overrideWith(

--- a/test/integration/settings_persistence_workflow_test.dart
+++ b/test/integration/settings_persistence_workflow_test.dart
@@ -26,14 +26,14 @@ void main() {
       testWidgets('seed color change survives ThemeProvider recreation',
           (tester) async {
         // Session 1: change theme color
-        final provider1 = ThemeProvider();
+        final provider1 = ThemeProvider(settingsContainer);
         provider1.updateThemeFromSeedColor(Colors.blue);
 
         // Persist to settings (normally done by ThemeSettingsWidget)
         settingsContainer.activeUserSettings.themeSeedColor = Colors.blue;
 
         // Session 2: recreate provider (simulates app restart)
-        final provider2 = ThemeProvider();
+        final provider2 = ThemeProvider(settingsContainer);
 
         expect(provider2.seedColor, equals(Colors.blue));
       });
@@ -41,7 +41,7 @@ void main() {
       testWidgets('dark mode toggle survives ThemeProvider recreation',
           (tester) async {
         // Session 1: enable dark mode
-        final provider1 = ThemeProvider();
+        final provider1 = ThemeProvider(settingsContainer);
         expect(provider1.state.brightness, Brightness.light);
 
         provider1.toggleDarkMode(true);
@@ -51,14 +51,14 @@ void main() {
         settingsContainer.activeUserSettings.darkThemeMode = true;
 
         // Session 2: recreate
-        final provider2 = ThemeProvider();
+        final provider2 = ThemeProvider(settingsContainer);
 
         expect(provider2.state.brightness, Brightness.dark);
       });
 
       testWidgets('default seed color is used when no settings persisted',
           (tester) async {
-        final provider = ThemeProvider();
+        final provider = ThemeProvider(settingsContainer);
 
         expect(provider.seedColor, equals(defaultSeedColor));
       });
@@ -66,7 +66,7 @@ void main() {
 
     group('locale persistence across provider recreation', () {
       test('locale change persists to settingsContainer automatically', () {
-        final provider = LocaleProvider();
+        final provider = LocaleProvider(settingsContainer);
 
         provider.setLocale(const Locale('de'));
 
@@ -79,11 +79,11 @@ void main() {
 
       test('locale survives LocaleProvider recreation', () {
         // Session 1: change to German
-        final provider1 = LocaleProvider();
+        final provider1 = LocaleProvider(settingsContainer);
         provider1.setLocale(const Locale('de'));
 
         // Session 2: recreate (reads from settingsContainer)
-        final provider2 = LocaleProvider();
+        final provider2 = LocaleProvider(settingsContainer);
 
         expect(provider2.state, equals(const Locale('de')));
       });
@@ -93,8 +93,8 @@ void main() {
       testWidgets('theme + locale + dark mode all persist across restart',
           (tester) async {
         // Session 1: change multiple settings
-        final theme1 = ThemeProvider();
-        final locale1 = LocaleProvider();
+        final theme1 = ThemeProvider(settingsContainer);
+        final locale1 = LocaleProvider(settingsContainer);
 
         theme1.updateThemeFromSeedColor(Colors.deepPurple);
         theme1.toggleDarkMode(true);
@@ -105,8 +105,8 @@ void main() {
         settingsContainer.activeUserSettings.darkThemeMode = true;
 
         // Session 2: recreate all providers
-        final theme2 = ThemeProvider();
-        final locale2 = LocaleProvider();
+        final theme2 = ThemeProvider(settingsContainer);
+        final locale2 = LocaleProvider(settingsContainer);
 
         expect(theme2.seedColor, equals(Colors.deepPurple));
         expect(theme2.state.brightness, Brightness.dark);
@@ -120,15 +120,15 @@ void main() {
         settingsContainer.activeUserSettings.darkThemeMode = true;
         settingsContainer.activeUserSettings.languageCode = 'de';
 
-        final themeA = ThemeProvider();
+        final themeA = ThemeProvider(settingsContainer);
         expect(themeA.seedColor, equals(Colors.blue));
         expect(themeA.state.brightness, Brightness.dark);
 
         // Switch to user B (fresh defaults)
         settingsContainer.activeUserSettings = UserSettings.fromEmpty();
 
-        final themeB = ThemeProvider();
-        final localeB = LocaleProvider();
+        final themeB = ThemeProvider(settingsContainer);
+        final localeB = LocaleProvider(settingsContainer);
 
         expect(themeB.seedColor, equals(defaultSeedColor));
         expect(themeB.state.brightness, Brightness.light);
@@ -138,8 +138,8 @@ void main() {
       testWidgets(
           'ThemeProvider does not auto-persist but LocaleProvider does',
           (tester) async {
-        final theme = ThemeProvider();
-        final locale = LocaleProvider();
+        final theme = ThemeProvider(settingsContainer);
+        final locale = LocaleProvider(settingsContainer);
 
         // ThemeProvider updates state but NOT settingsContainer
         theme.updateThemeFromSeedColor(Colors.red);


### PR DESCRIPTION
- Replaced the deprecated SettingsContainer with a new SettingsProvider for managing application settings via Riverpod.
- Updated various components and services to utilize the new settings provider, ensuring consistent access to user settings across the application.
- Removed direct references to SettingsContainer, enhancing code maintainability and reducing potential issues with state management.
- Added necessary adjustments in the backup, notification, and theme settings to align with the new provider structure.