### PR TITLE
docs: add architecture decision records and enhance README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ lib/
 - **Schema-driven DB**: Each model declares its own `columns`, `migrations`, and serialization
 - **Repository Pattern**: Unified CRUD via `DbRepository<T>`
 
+### Architecture Decision Records
+
+Key architectural decisions are documented in [`docs/architecture/`](docs/architecture/):
+
+| ADR | Decision |
+|-----|----------|
+| [ADR-001](docs/architecture/ADR-001-state-management-riverpod.md) | State Management with Riverpod |
+| [ADR-002](docs/architecture/ADR-002-local-first-supabase-sync.md) | Local-First Architecture with Supabase Sync |
+| [ADR-003](docs/architecture/ADR-003-feature-module-structure.md) | Feature Module Structure |
+| [ADR-004](docs/architecture/ADR-004-security-model.md) | Security Model |
+| [ADR-005](docs/architecture/ADR-005-multi-platform-support.md) | Multi-Platform Support |
+
 ---
 
 ## 🏗️ Building

--- a/docs/architecture/ADR-001-state-management-riverpod.md
+++ b/docs/architecture/ADR-001-state-management-riverpod.md
@@ -1,0 +1,67 @@
+# ADR-001: State Management with Riverpod
+
+## Status
+Accepted
+
+## Context
+SimpleDiary needs a state management solution that handles reactive UI updates, database-backed persistence, and multi-provider coordination (theme, locale, user session, diary data). The solution must support testability via provider overrides and compile-time type safety to catch errors early.
+
+Flutter offers several state management options: Provider, BLoC, GetX, MobX, and Riverpod. Each has different trade-offs in terms of type safety, testability, boilerplate, and ecosystem maturity.
+
+## Decision
+We chose **flutter_riverpod** (^2.3.7) with the **StateNotifier** pattern as the primary state management solution.
+
+### Provider types used
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `StateNotifierProvider` | Core mutable state with custom logic | `ThemeProvider`, `UserDataProvider`, all `DbRepository` subclasses |
+| `Provider` | Synchronous derived/computed state | `currentStreakProvider`, `defaultCategoryProvider` |
+| `FutureProvider` | Async initialization | `dashboardStatsProvider`, `biometricAvailableProvider` |
+| `StateProvider` | Simple atomic values | `skipBiometricProvider`, `isDemoModeProvider` |
+
+### Key patterns
+
+**1. DbRepository as StateNotifier:** All database-backed entities use `DbRepository<T> extends StateNotifier<List<T>>`, unifying CRUD operations with reactive state. Simple entities use the `createDbProvider<T>()` one-liner factory; entities with custom logic subclass `DbRepository` directly.
+
+**2. Granular providers via `select()`:** Performance-critical UI (dashboard) uses `ref.watch(provider.select(...))` to rebuild only when specific fields change, not the entire state.
+
+**3. Provider composition:** Providers depend on other providers through `ref.watch()` chains, enabling automatic cache invalidation when upstream state changes.
+
+**4. Testable overrides:** `ProviderScope(overrides: [...])` allows swapping real providers with test doubles in both widget tests and integration tests.
+
+## Consequences
+
+### Benefits
+- **Compile-time type safety:** `StateNotifierProvider<ThemeProvider, ThemeData>` enforces correct types; no string-based lookups or runtime casts
+- **Unified persistence + state:** `DbRepository` combines SQLite CRUD with Riverpod's reactive updates in a single class, eliminating the gap between persistence and UI state
+- **Testability:** All 850+ tests use `ProviderContainer` or `ProviderScope` overrides to inject test doubles without touching real databases
+- **No context dependency:** Providers can be accessed via `ref` anywhere, not just inside `build()` methods, simplifying service-layer logic
+- **Granular rebuilds:** `select()` and separate derived providers prevent unnecessary widget rebuilds
+
+### Trade-offs
+- **Learning curve:** Riverpod's provider types and `ref.watch` vs `ref.read` distinction require understanding
+- **Legacy singleton coexistence:** The global `settingsContainer` singleton predates full Riverpod adoption and is now wrapped in a `settingsProvider` for gradual migration
+- **Unused dependency:** The `provider` package (^6.0.5) remains in pubspec.yaml but is completely unused — a cleanup candidate
+
+## Alternatives Considered
+
+### Provider (package:provider)
+- Simpler API but relies on `BuildContext` for access, making service-layer usage awkward
+- No compile-time safety for provider types (runtime `ProviderNotFoundException`)
+- Was originally used; fully migrated to Riverpod
+
+### BLoC (flutter_bloc)
+- Strong separation of events/states but introduces significant boilerplate (Event classes, State classes, Bloc classes per feature)
+- Overkill for a diary app where most state is simple CRUD lists
+- Stream-based architecture adds complexity without proportional benefit here
+
+### GetX
+- Minimal boilerplate but sacrifices type safety and testability
+- Global state access pattern conflicts with modular architecture goals
+- Less predictable rebuild behavior
+
+---
+
+*Decided: Project inception*
+*Last reviewed: 2026-02-27*

--- a/docs/architecture/ADR-002-local-first-supabase-sync.md
+++ b/docs/architecture/ADR-002-local-first-supabase-sync.md
@@ -1,0 +1,75 @@
+# ADR-002: Local-First Architecture with Optional Supabase Sync
+
+## Status
+Accepted
+
+## Context
+A personal diary application requires high reliability and privacy. Users expect their journal entries to be available instantly, work without internet, and remain private. At the same time, some users want multi-device access and cloud backup as an optional convenience.
+
+The key tension is between a cloud-first approach (simpler sync but requires connectivity) and a local-first approach (always available but sync is more complex).
+
+## Decision
+We chose a **local-first architecture with SQLite as the primary datastore and optional Supabase sync**.
+
+### Core design
+
+- **All reads and writes go to local SQLite first.** The app is fully functional offline.
+- **Supabase sync is optional and on-demand.** Users explicitly trigger sync from the Synchronization page; there is no automatic background sync.
+- **Per-user database files:** Each user profile gets an isolated `${userId}.db` file, providing complete data separation.
+- **Last-write-wins conflict resolution:** Supabase `upsert()` replaces records by primary key. No timestamp-based versioning or three-way merge.
+
+### Sync flow
+
+**Upload:** Local diary days, notes, and templates are batch-upserted to Supabase (batch size: 50, retry with exponential backoff up to 3 attempts).
+
+**Download:** All records for the authenticated user are fetched and inserted locally via `addElement()` with `ConflictAlgorithm.ignore` (skips existing duplicates).
+
+### Additional data portability
+
+| Format | Use case |
+|--------|----------|
+| JSON export/import | Full data portability with optional AES-256 encryption |
+| ICS export/import | Calendar app integration via iCalendar format |
+| PDF export | Printable diary reports with date range filtering |
+| Scheduled backups | Automatic local backups (daily/weekly/monthly) with pruning |
+
+## Consequences
+
+### Benefits
+- **Always available:** No network dependency for daily use; the app works identically offline
+- **Privacy by default:** Data stays on-device unless the user explicitly configures Supabase
+- **Simple mental model:** Users understand "my data is on my phone/computer" without cloud complexity
+- **Platform resilience:** Desktop platforms (Linux/Windows) work without Google/Apple cloud services
+- **Data ownership:** JSON export means users can always extract their data
+
+### Trade-offs
+- **No real-time sync:** Changes on one device don't automatically appear on another; users must manually trigger sync
+- **Last-write-wins can lose edits:** If the same entry is modified on two devices between syncs, the last sync overwrites the other
+- **Full sync (not incremental):** Each sync operation processes all records, which is acceptable for personal diary volumes (<10K entries) but wouldn't scale to larger datasets
+- **Backup scheduling differs by platform:** Android uses WorkManager for true background scheduling; desktop only checks on app startup
+
+## Alternatives Considered
+
+### Cloud-first (Supabase only, no local SQLite)
+- Simpler sync (single source of truth) but requires constant connectivity
+- Unacceptable for a diary app where users expect immediate, private access
+- Would exclude offline desktop usage entirely
+
+### CRDTs (Conflict-free Replicated Data Types)
+- Elegant conflict resolution without server coordination
+- Significant implementation complexity for a diary app where conflicts are rare (single-user, sequential entries)
+- Library ecosystem for Dart/Flutter is immature
+
+### Firebase / Firestore
+- Mature real-time sync with offline support built in
+- Vendor lock-in to Google ecosystem; conflicts with privacy-first goals
+- Pricing model scales with reads/writes, unpredictable for heavy journaling
+
+### Local-only (no sync at all)
+- Simplest implementation but leaves users without any multi-device or backup option
+- Adding sync later would require more architectural changes than building it optionally from the start
+
+---
+
+*Decided: Project inception*
+*Last reviewed: 2026-02-27*

--- a/docs/architecture/ADR-003-feature-module-structure.md
+++ b/docs/architecture/ADR-003-feature-module-structure.md
@@ -1,0 +1,113 @@
+# ADR-003: Feature Module Structure
+
+## Status
+Accepted
+
+## Context
+As SimpleDiary grew beyond a handful of screens, the codebase needed a clear organizational strategy to keep features isolated, dependencies manageable, and onboarding straightforward. Without explicit module boundaries, cross-feature imports tend to create circular dependencies and make changes risky.
+
+The question was how to split the codebase: by technical layer (all models together, all widgets together) or by business domain (each feature owns its full stack).
+
+## Decision
+We chose a **feature-first module structure** inspired by Clean Architecture, with a shared `core/` layer for cross-cutting infrastructure.
+
+### Directory layout
+
+```
+lib/
+├── core/                          # Shared infrastructure (no business logic)
+│   ├── authentication/            # Password hashing service
+│   ├── database/                  # DbEntity, DbRepository, DbColumn, migrations
+│   ├── encryption/                # AES encryptor
+│   ├── provider/                  # Global providers (theme, locale)
+│   ├── services/                  # BackupService, NotificationService, BiometricService
+│   ├── settings/                  # SettingsContainer, user/backup/biometric settings
+│   ├── widgets/                   # Shared UI kit (AppCard, AppDialog, AppSpacing)
+│   └── utils/                     # Platform detection, date utilities
+│
+└── features/                      # Business domain modules
+    ├── notes/
+    │   ├── data/models/           # Note, NoteCategory, NoteAttachment (DbEntity)
+    │   ├── data/repositories/     # Business logic (optional)
+    │   ├── domain/providers/      # Riverpod providers
+    │   └── presentation/          # Pages and widgets
+    ├── day_rating/
+    ├── dashboard/
+    ├── goals/
+    ├── habits/
+    └── ...
+```
+
+### Layer responsibilities
+
+| Layer | Contains | Depends on |
+|-------|----------|------------|
+| `data/models/` | DbEntity subclasses with schema, serialization, and value semantics | Core database types only |
+| `data/repositories/` | Pure business logic functions (no state, no UI) | Models from same feature |
+| `domain/providers/` | Riverpod providers wiring models to DbRepository | Core database, feature models |
+| `presentation/pages/` | Full-screen widgets (ConsumerWidget/ConsumerStatefulWidget) | Feature providers, core widgets |
+| `presentation/widgets/` | Reusable UI components scoped to the feature | Feature models, core widgets |
+
+### Dependency rules
+
+- **Features import core** — always allowed
+- **Features may import other features' models and providers** — allowed for cross-feature data access (e.g., dashboard reads diary days from day_rating)
+- **Core does not import features** — enforced to prevent circular dependencies
+
+### When to create a new feature vs extend existing
+
+A new feature directory is warranted when the domain concept has:
+1. Its own data model(s) persisted to the database
+2. Its own screen(s) or navigation entry
+3. Independent lifecycle (can be developed/tested in isolation)
+
+If the functionality is a sub-concern of an existing feature (e.g., note search within notes), it stays within the existing feature module.
+
+## Consequences
+
+### Benefits
+- **Discoverability:** New developers find all note-related code under `features/notes/`, not scattered across `models/`, `widgets/`, `providers/` directories
+- **Isolation:** Changes to goals don't risk breaking notes; each feature has clear boundaries
+- **Testability:** Test files mirror the feature structure (`test/features/notes/`), making it obvious what's covered
+- **Scalability:** New features follow a repeatable pattern — create directory, add model, add provider, add UI
+- **Parallel development:** Multiple features can be worked on simultaneously with minimal merge conflicts
+
+### Trade-offs
+- **Cross-feature imports exist:** Dashboard, calendar, and synchronization features necessarily import models from day_rating and notes, creating a fan-in dependency pattern
+- **Shared logic placement:** Some logic (e.g., date utilities) could arguably live in a feature but is placed in core for reuse — this boundary requires judgment
+- **Repository layer is optional:** Simpler features skip `data/repositories/` entirely, leading to slight inconsistency in structure depth across features
+
+## Alternatives Considered
+
+### Layer-first organization
+```
+lib/
+├── models/        # All models together
+├── providers/     # All providers together
+├── pages/         # All pages together
+└── widgets/       # All widgets together
+```
+- Familiar from small projects but breaks down at scale
+- Finding "all code related to notes" requires searching across 4+ directories
+- No clear ownership boundaries; circular dependencies emerge easily
+
+### Strict Clean Architecture (separate packages per layer)
+- Maximum isolation via Dart packages with explicit `pubspec.yaml` dependencies
+- Excessive boilerplate for a single-developer diary app
+- Package-level boundaries are more appropriate for large team projects
+
+### Feature-first without layers (flat feature directories)
+```
+features/notes/
+├── note.dart
+├── note_provider.dart
+├── notes_page.dart
+└── note_widget.dart
+```
+- Simpler for small features but loses the visual separation between data, logic, and UI
+- Harder to enforce dependency direction (UI importing models is fine; models importing UI is not)
+
+---
+
+*Decided: Project inception*
+*Last reviewed: 2026-02-27*

--- a/docs/architecture/ADR-004-security-model.md
+++ b/docs/architecture/ADR-004-security-model.md
@@ -1,0 +1,104 @@
+# ADR-004: Security Model
+
+## Status
+Accepted
+
+## Context
+SimpleDiary stores personal journal entries, mood data, and wellbeing metrics — sensitive information that users expect to remain private. The security model must protect data at rest (on-device storage, backups, exports), authenticate users reliably, and support biometric convenience on mobile platforms.
+
+Key constraints:
+- No server-side session management (local-first architecture)
+- Must work offline without token refresh
+- Multiple user profiles on the same device
+- Backup files may be stored on shared storage or transferred between devices
+
+## Decision
+We adopted a **layered security model** combining PBKDF2 password hashing, AES-256-CBC data encryption, and platform-native biometric authentication.
+
+### 1. Password hashing: PBKDF2-SHA256
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | PBKDF2 with HMAC-SHA256 (via PointyCastle) |
+| Salt | 32 bytes (256 bits) of cryptographically secure random data, unique per user |
+| Iterations | 10,000 rounds |
+| Key length | 32 bytes (256 bits) |
+| Output | Base64-encoded hash stored in `UserData.passwordHash` |
+
+Passwords are never stored in cleartext on disk. The cleartext password is held in memory only during an active session (required for encryption key derivation).
+
+### 2. Data encryption: AES-256-CBC
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | AES in CBC mode |
+| Key size | 256 bits (32 bytes) |
+| IV | 16 bytes, randomly generated per encryption operation |
+| IV storage | Prepended to ciphertext |
+| Library | `encrypt` package |
+
+Used for: backup files, JSON/ICS exports, and file-level encryption.
+
+### 3. Encryption key derivation (domain-separated)
+
+The encryption key is derived separately from the password hash to prevent cross-protocol attacks:
+
+```
+Encryption key = PBKDF2(password, salt + "db_encryption_key", iterations: 20,000)
+```
+
+- **Domain separation:** Appending `"db_encryption_key"` context to the salt ensures the encryption key differs from the password hash even with the same password and salt
+- **Higher iterations:** 20,000 rounds (vs 10,000 for password hashing) for additional brute-force resistance on the encryption key
+
+### 4. Biometric authentication
+
+- **Platforms:** Android and iOS only (desktop platforms return `unsupportedPlatform`)
+- **Implementation:** Delegates to `local_auth` package for hardware-backed biometric prompts
+- **Credential storage:** After successful biometric enrollment, credentials are stored via `flutter_secure_storage` (Android KeyStore / iOS Keychain)
+- **Auto-lock:** Configurable timeout (0 = always require biometric on resume)
+
+### 5. Per-user database isolation
+
+Each user profile gets a separate SQLite database file (`${userId}.db`). Switching users closes the current database connection and opens the new user's file, providing complete data isolation without row-level access control.
+
+## Consequences
+
+### Benefits
+- **Defense in depth:** Three independent layers (hashing, encryption, biometric) each protect against different attack vectors
+- **Domain-separated key derivation:** Compromising the password hash does not reveal the encryption key, and vice versa
+- **Random IVs per operation:** Identical plaintexts produce different ciphertexts, preventing pattern analysis on encrypted backups
+- **Hardware-backed biometrics:** Delegates to OS-level security (Secure Enclave / TEE) rather than implementing custom biometric logic
+- **Offline-compatible:** No server round-trips needed for authentication; all crypto operations are local
+
+### Trade-offs
+- **Session cleartext in memory:** The cleartext password must be held in memory during the session for encryption key derivation; this is unavoidable without a separate key management service
+- **No authenticated encryption:** CBC mode provides confidentiality but not integrity verification (no HMAC or GCM). A tampered backup would decrypt to garbage rather than being explicitly rejected
+- **Desktop has no biometric option:** Linux and Windows users can only use password authentication; there is no equivalent to mobile biometric hardware
+- **10,000 PBKDF2 iterations:** While meeting NIST baseline recommendations, modern guidance suggests higher iteration counts (100,000+). This was chosen as a balance between security and mobile device performance
+
+## Alternatives Considered
+
+### bcrypt / Argon2 for password hashing
+- Argon2 is the current OWASP recommendation with memory-hard properties
+- No mature pure-Dart implementation at time of decision; would require native FFI bindings
+- PBKDF2 has well-tested Dart implementations via PointyCastle and meets security requirements
+
+### AES-GCM (authenticated encryption)
+- Provides both confidentiality and integrity in a single operation
+- Would detect tampered backup files rather than silently decrypting to garbage
+- The `encrypt` package supports GCM but was not available when the encryption layer was initially built; a future migration is possible
+
+### PIN-based authentication (instead of password)
+- Simpler UX for quick access
+- Severely limited keyspace (4-6 digits) makes brute-force trivial on local databases
+- Password provides adequate security with biometric available as the convenience option
+
+### No encryption (rely on OS-level protection)
+- Simpler implementation
+- Leaves backup files and exports completely unprotected when transferred or stored on shared media
+- Unacceptable for a privacy-focused diary app
+
+---
+
+*Decided: Project inception*
+*Last reviewed: 2026-02-27*

--- a/docs/architecture/ADR-005-multi-platform-support.md
+++ b/docs/architecture/ADR-005-multi-platform-support.md
@@ -1,0 +1,87 @@
+# ADR-005: Multi-Platform Support
+
+## Status
+Accepted
+
+## Context
+SimpleDiary targets users who journal on their phone (Android) and their desktop (Linux, Windows). Flutter enables a single codebase across platforms, but several subsystems require platform-specific handling: database initialization, background task scheduling, biometric authentication, file storage paths, and native permissions.
+
+The question was how to manage these platform differences: conditional imports (compile-time), runtime platform checks, or separate platform packages.
+
+## Decision
+We chose **runtime platform detection via a global singleton** with platform-specific code paths gated by simple `if` checks.
+
+### Platform detection
+
+```dart
+// lib/core/utils/platform_utils.dart
+enum ActivePlatform { android, ios, linux, windows, macOS, web }
+
+final activePlatform = ActivePlatformClass();  // Global singleton
+```
+
+All platform-specific behavior branches on `activePlatform.platform` at runtime. No conditional imports or separate platform packages are used.
+
+### Platform-specific code paths
+
+| Subsystem | Android | Linux / Windows |
+|-----------|---------|-----------------|
+| **Database** | `sqflite` (native wrapper) | `sqflite_common_ffi` (FFI binding, initialized in `main.dart`) |
+| **Background backups** | WorkManager for periodic scheduling | Overdue check on app startup only |
+| **Biometric auth** | `local_auth` + `flutter_secure_storage` | Unavailable (returns `unsupportedPlatform`) |
+| **File storage** | `/storage/emulated/0/{projectName}` | App documents directory via `path_provider` |
+| **Permissions** | Runtime `manageExternalStorage` request | Not required |
+| **Notifications** | Android-specific initialization settings | Linux-specific initialization settings |
+
+### CI/CD builds
+
+Each platform has a dedicated CI job with its own OS runner and toolchain:
+- **Test:** ubuntu-latest (all platforms share unit tests)
+- **Android:** ubuntu-latest + Java 17 (APK + App Bundle)
+- **Linux:** ubuntu-latest + GTK3/libsecret dependencies
+- **Windows:** windows-latest + MSVC toolchain
+
+## Consequences
+
+### Benefits
+- **Single codebase:** One Dart codebase serves all three platforms; no platform-specific forks or packages to maintain
+- **Simple branching:** `if (activePlatform.platform == ActivePlatform.android)` is immediately understandable; no metaprogramming or build configuration
+- **Unified dependency tree:** All platform dependencies are bundled; unused ones are tree-shaken by the compiler for each target
+- **Shared test suite:** All 850+ unit tests run on a single platform (ubuntu) and verify logic that applies across all targets
+- **Feature degradation over failure:** Desktop gracefully reports "biometric unavailable" instead of crashing on unsupported API calls
+
+### Trade-offs
+- **Runtime overhead (negligible):** Platform checks happen at runtime rather than compile-time, but the cost is trivial for infrequent initialization-time checks
+- **Unused dependencies bundled:** Packages like `local_auth` and `workmanager` are included in desktop builds even though their features are gated off; this slightly increases binary size
+- **Desktop backup gap:** Linux/Windows cannot schedule true background backups; the startup-check approach misses overdue backups if the app isn't launched
+- **No iOS/macOS/Web builds:** While the enum includes these platforms, CI/CD only builds Android, Linux, and Windows. iOS/macOS support would require additional CI runners and entitlements
+
+## Alternatives Considered
+
+### Conditional imports (compile-time platform split)
+```dart
+import 'database_mobile.dart' if (dart.library.ffi) 'database_desktop.dart';
+```
+- Eliminates unused code at compile time
+- Adds complexity with paired implementation files for each platform difference
+- Overkill when platform differences are limited to ~5 initialization-time checks
+
+### Separate platform packages (federated plugins)
+- Maximum isolation; each platform is its own Dart package
+- Appropriate for published plugins but excessive for an application with minor platform differences
+- Would fragment the codebase and complicate cross-platform debugging
+
+### Web-first with PWA
+- Single deployment target, no app store requirements
+- Cannot access SQLite, biometric hardware, or filesystem directly
+- Incompatible with the local-first, privacy-focused architecture (see ADR-002)
+
+### Platform-specific native modules
+- Could unlock platform capabilities (e.g., Windows Hello for biometrics)
+- Requires maintaining Kotlin/Swift/C++ code alongside Dart
+- Current Flutter plugin ecosystem (`local_auth`, `sqflite`) already abstracts most platform differences adequately
+
+---
+
+*Decided: Project inception*
+*Last reviewed: 2026-02-27*


### PR DESCRIPTION
- Introduced Architecture Decision Records (ADRs) to document key architectural choices, including state management with Riverpod, local-first architecture with Supabase sync, feature module structure, security model, and multi-platform support.
- Updated README to include a new section for ADRs, providing a clear overview of architectural decisions and their implications for the project.