### PR TITLE
feat: add activity details feature with clickable top activities on d…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ windows/runner
 
 # issue files
 *issue_*.md
+#*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@docs/TECH_STACK.md
+@test/TEST_COVERAGE.md

--- a/lib/features/dashboard/data/repositories/activity_detail_repository.dart
+++ b/lib/features/dashboard/data/repositories/activity_detail_repository.dart
@@ -1,0 +1,164 @@
+import 'package:day_tracker/core/utils/utils.dart';
+import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/data/models/note_category.dart';
+
+/// Statistics for a single activity (note category)
+class ActivityStats {
+  final String activityName;
+  final NoteCategory category;
+  final int totalNotes;
+  final int associatedDays;
+  final double averageDayRating;
+  final DateTime? firstOccurrence;
+  final DateTime? lastOccurrence;
+
+  const ActivityStats({
+    required this.activityName,
+    required this.category,
+    required this.totalNotes,
+    required this.associatedDays,
+    required this.averageDayRating,
+    this.firstOccurrence,
+    this.lastOccurrence,
+  });
+
+  ActivityStats copyWith({
+    String? activityName,
+    NoteCategory? category,
+    int? totalNotes,
+    int? associatedDays,
+    double? averageDayRating,
+    DateTime? firstOccurrence,
+    DateTime? lastOccurrence,
+  }) {
+    return ActivityStats(
+      activityName: activityName ?? this.activityName,
+      category: category ?? this.category,
+      totalNotes: totalNotes ?? this.totalNotes,
+      associatedDays: associatedDays ?? this.associatedDays,
+      averageDayRating: averageDayRating ?? this.averageDayRating,
+      firstOccurrence: firstOccurrence ?? this.firstOccurrence,
+      lastOccurrence: lastOccurrence ?? this.lastOccurrence,
+    );
+  }
+}
+
+/// Summary entry for dashboard display (category name + count)
+class ActivitySummary {
+  final String activityName;
+  final NoteCategory category;
+  final int count;
+
+  const ActivitySummary({
+    required this.activityName,
+    required this.category,
+    required this.count,
+  });
+}
+
+/// Repository for activity detail calculations
+class ActivityDetailRepository {
+  /// Get statistics for a specific activity category
+  ActivityStats getActivityStats({
+    required String activityName,
+    required List<Note> notes,
+    required List<DiaryDay> diaryDays,
+  }) {
+    final activityNotes = getNotesByActivity(activityName, notes);
+    final activityDays = getDaysByActivity(activityName, notes, diaryDays);
+
+    double averageRating = 0;
+    if (activityDays.isNotEmpty) {
+      double totalScore = 0;
+      int scoredDays = 0;
+      for (final day in activityDays) {
+        if (day.ratings.isNotEmpty) {
+          totalScore += day.overallScore;
+          scoredDays++;
+        }
+      }
+      if (scoredDays > 0) {
+        averageRating = totalScore / scoredDays;
+      }
+    }
+
+    DateTime? firstOccurrence;
+    DateTime? lastOccurrence;
+    if (activityNotes.isNotEmpty) {
+      final sorted = List<Note>.from(activityNotes)
+        ..sort((a, b) => a.from.compareTo(b.from));
+      firstOccurrence = sorted.first.from;
+      lastOccurrence = sorted.last.from;
+    }
+
+    final category = activityNotes.isNotEmpty
+        ? activityNotes.first.noteCategory
+        : NoteCategory.fromString(activityName);
+
+    return ActivityStats(
+      activityName: activityName,
+      category: category,
+      totalNotes: activityNotes.length,
+      associatedDays: activityDays.length,
+      averageDayRating: averageRating,
+      firstOccurrence: firstOccurrence,
+      lastOccurrence: lastOccurrence,
+    );
+  }
+
+  /// Get all notes for a specific activity category
+  List<Note> getNotesByActivity(String activityName, List<Note> notes) {
+    return notes
+        .where((note) => note.noteCategory.title == activityName)
+        .toList()
+      ..sort((a, b) => b.from.compareTo(a.from));
+  }
+
+  /// Get all diary days that contain notes of a specific activity category
+  List<DiaryDay> getDaysByActivity(
+    String activityName,
+    List<Note> notes,
+    List<DiaryDay> diaryDays,
+  ) {
+    final activityNotes = getNotesByActivity(activityName, notes);
+    final activityDates = activityNotes
+        .map((note) => DateTime(note.from.year, note.from.month, note.from.day))
+        .toSet();
+
+    return diaryDays
+        .where((day) => activityDates.any((date) => Utils.isSameDay(day.day, date)))
+        .toList()
+      ..sort((a, b) => b.day.compareTo(a.day));
+  }
+
+  /// Extract top activities with counts and category info for dashboard display
+  List<ActivitySummary> extractTopActivitySummaries(
+    List<Note> notes,
+    List<NoteCategory> categories,
+  ) {
+    if (notes.isEmpty) return [];
+
+    final Map<String, int> activityCounts = {};
+    final Map<String, NoteCategory> categoryMap = {};
+
+    for (final note in notes) {
+      final name = note.noteCategory.title;
+      activityCounts[name] = (activityCounts[name] ?? 0) + 1;
+      categoryMap[name] = note.noteCategory;
+    }
+
+    final sorted = activityCounts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return sorted.take(5).map((entry) {
+      final category = categoryMap[entry.key] ??
+          NoteCategory.fromString(entry.key);
+      return ActivitySummary(
+        activityName: entry.key,
+        category: category,
+        count: entry.value,
+      );
+    }).toList();
+  }
+}

--- a/lib/features/dashboard/domain/providers/activity_detail_provider.dart
+++ b/lib/features/dashboard/domain/providers/activity_detail_provider.dart
@@ -1,0 +1,50 @@
+import 'package:day_tracker/features/dashboard/data/repositories/activity_detail_repository.dart';
+import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
+import 'package:day_tracker/features/day_rating/domain/providers/diary_day_local_db_provider.dart';
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/domain/providers/category_local_db_provider.dart';
+import 'package:day_tracker/features/notes/domain/providers/note_local_db_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provider for ActivityDetailRepository
+final activityDetailRepositoryProvider = Provider<ActivityDetailRepository>((ref) {
+  return ActivityDetailRepository();
+});
+
+/// Provider for top activity summaries (used in dashboard)
+final topActivitySummariesProvider = Provider<List<ActivitySummary>>((ref) {
+  final repository = ref.watch(activityDetailRepositoryProvider);
+  final notes = ref.watch(notesLocalDataProvider);
+  final categories = ref.watch(categoryLocalDataProvider);
+  return repository.extractTopActivitySummaries(notes, categories);
+});
+
+/// Family provider for activity stats (used in detail page)
+final activityStatsProvider =
+    Provider.family<ActivityStats, String>((ref, activityName) {
+  final repository = ref.watch(activityDetailRepositoryProvider);
+  final notes = ref.watch(notesLocalDataProvider);
+  final diaryDays = ref.watch(diaryDayLocalDbDataProvider);
+  return repository.getActivityStats(
+    activityName: activityName,
+    notes: notes,
+    diaryDays: diaryDays,
+  );
+});
+
+/// Family provider for notes filtered by activity
+final notesByActivityProvider =
+    Provider.family<List<Note>, String>((ref, activityName) {
+  final repository = ref.watch(activityDetailRepositoryProvider);
+  final notes = ref.watch(notesLocalDataProvider);
+  return repository.getNotesByActivity(activityName, notes);
+});
+
+/// Family provider for diary days associated with an activity
+final daysByActivityProvider =
+    Provider.family<List<DiaryDay>, String>((ref, activityName) {
+  final repository = ref.watch(activityDetailRepositoryProvider);
+  final notes = ref.watch(notesLocalDataProvider);
+  final diaryDays = ref.watch(diaryDayLocalDbDataProvider);
+  return repository.getDaysByActivity(activityName, notes, diaryDays);
+});

--- a/lib/features/dashboard/presentation/pages/activity_detail_page.dart
+++ b/lib/features/dashboard/presentation/pages/activity_detail_page.dart
@@ -1,0 +1,408 @@
+import 'package:day_tracker/core/widgets/app_ui_kit.dart';
+import 'package:day_tracker/features/dashboard/data/repositories/activity_detail_repository.dart';
+import 'package:day_tracker/features/dashboard/domain/providers/activity_detail_provider.dart';
+import 'package:day_tracker/features/dashboard/presentation/pages/diary_day_detail_page.dart';
+import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/domain/providers/note_editing_page_provider.dart';
+import 'package:day_tracker/features/notes/presentation/pages/note_viewing_page.dart';
+import 'package:day_tracker/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+/// Page showing detailed statistics and entries for a specific activity category
+class ActivityDetailPage extends ConsumerWidget {
+  final String activityName;
+
+  const ActivityDetailPage({super.key, required this.activityName});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final stats = ref.watch(activityStatsProvider(activityName));
+    final activityNotes = ref.watch(notesByActivityProvider(activityName));
+    final activityDays = ref.watch(daysByActivityProvider(activityName));
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final locale = Localizations.localeOf(context).languageCode;
+
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      appBar: AppBar(
+        backgroundColor: theme.colorScheme.surfaceContainer,
+        foregroundColor: theme.colorScheme.onSurface,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              backgroundColor: stats.category.color,
+              radius: 8,
+            ),
+            AppSpacing.horizontalXs,
+            Flexible(
+              child: Text(
+                l10n.activityDetails,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: PageGradientBackground(
+        child: ListView(
+          padding: AppSpacing.paddingAllMd,
+          children: [
+            // Activity name header
+            _buildHeader(context, stats),
+            AppSpacing.verticalMd,
+
+            // Summary stats card
+            _buildSummaryCard(context, stats, locale),
+            AppSpacing.verticalXl,
+
+            // Associated days section
+            if (activityDays.isNotEmpty) ...[
+              _buildSectionTitle(context, l10n.associatedDays, activityDays.length),
+              AppSpacing.verticalXs,
+              ...activityDays.take(10).map((day) =>
+                  _buildDayItem(context, day, locale)),
+              if (activityDays.length > 10)
+                Padding(
+                  padding: AppSpacing.paddingVerticalXs,
+                  child: Text(
+                    l10n.andMoreEntries(activityDays.length - 10),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontStyle: FontStyle.italic,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              AppSpacing.verticalXl,
+            ],
+
+            // Notes section
+            if (activityNotes.isNotEmpty) ...[
+              _buildSectionTitle(context, l10n.notesInCategory, activityNotes.length),
+              AppSpacing.verticalXs,
+              ...activityNotes.take(20).map((note) =>
+                  _buildNoteItem(context, ref, note)),
+              if (activityNotes.length > 20)
+                Padding(
+                  padding: AppSpacing.paddingVerticalXs,
+                  child: Text(
+                    l10n.andMoreEntries(activityNotes.length - 20),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontStyle: FontStyle.italic,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+            ],
+
+            // Bottom spacing
+            AppSpacing.verticalXxl,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, ActivityStats stats) {
+    final theme = Theme.of(context);
+
+    return Row(
+      children: [
+        Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            color: stats.category.color.withValues(alpha: 0.2),
+            borderRadius: AppRadius.borderRadiusMd,
+          ),
+          child: Icon(
+            Icons.category_rounded,
+            color: stats.category.color,
+            size: 28,
+          ),
+        ),
+        AppSpacing.horizontalMd,
+        Expanded(
+          child: Text(
+            stats.activityName,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: theme.colorScheme.onSurface,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryCard(BuildContext context, ActivityStats stats, String locale) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return AppCard.elevated(
+      color: theme.colorScheme.surfaceContainer,
+      borderRadius: AppRadius.borderRadiusMd,
+      padding: AppSpacing.paddingAllMd,
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: _buildStatItem(
+                  context,
+                  icon: Icons.note_outlined,
+                  label: l10n.totalNotes,
+                  value: stats.totalNotes.toString(),
+                ),
+              ),
+              Expanded(
+                child: _buildStatItem(
+                  context,
+                  icon: Icons.calendar_today_outlined,
+                  label: l10n.associatedDays,
+                  value: stats.associatedDays.toString(),
+                ),
+              ),
+            ],
+          ),
+          AppSpacing.verticalMd,
+          Row(
+            children: [
+              Expanded(
+                child: _buildStatItem(
+                  context,
+                  icon: Icons.star_outline_rounded,
+                  label: l10n.averageRating,
+                  value: stats.averageDayRating > 0
+                      ? stats.averageDayRating.toStringAsFixed(1)
+                      : '-',
+                ),
+              ),
+              Expanded(
+                child: _buildStatItem(
+                  context,
+                  icon: Icons.date_range_outlined,
+                  label: l10n.dateRange,
+                  value: _formatDateRange(stats, locale),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatItem(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    final theme = Theme.of(context);
+
+    return Column(
+      children: [
+        Icon(icon, size: 24, color: theme.colorScheme.primary),
+        AppSpacing.verticalXs,
+        Text(
+          value,
+          style: theme.textTheme.titleLarge?.copyWith(
+            color: theme.colorScheme.onSurface,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSectionTitle(BuildContext context, String title, int count) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Flexible(
+          child: Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: theme.colorScheme.onSurface,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        Text(
+          l10n.nEntries(count),
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDayItem(BuildContext context, DiaryDay day, String locale) {
+    final theme = Theme.of(context);
+    final score = day.overallScore;
+    final scoreColor = _getScoreColor(score / 20.0);
+
+    return AppCard.flat(
+      color: theme.colorScheme.surfaceContainerHigh,
+      margin: const EdgeInsets.symmetric(vertical: 3),
+      borderRadius: AppRadius.borderRadiusSm,
+      onTap: () {
+        Navigator.of(context).push(
+          AppPageRoute(
+            builder: (context) => DiaryDayDetailPage(selectedDate: day.day),
+          ),
+        );
+      },
+      padding: AppSpacing.paddingAllSm,
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 20,
+            backgroundColor: scoreColor.withValues(
+              alpha: theme.colorScheme.brightness == Brightness.dark ? 0.3 : 0.2,
+            ),
+            child: Text(
+              '$score',
+              style: TextStyle(
+                color: scoreColor,
+                fontWeight: FontWeight.bold,
+                fontSize: 14,
+              ),
+            ),
+          ),
+          AppSpacing.horizontalMd,
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  DateFormat('EEEE, MMM d, y', locale).format(day.day),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                if (day.notes.isNotEmpty)
+                  Text(
+                    '${day.notes.length} ${day.notes.length == 1 ? 'note' : 'notes'}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Icon(
+            Icons.chevron_right,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoteItem(BuildContext context, WidgetRef ref, Note note) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return AppCard.flat(
+      color: theme.colorScheme.surfaceContainerHigh,
+      margin: const EdgeInsets.symmetric(vertical: 3),
+      borderRadius: AppRadius.borderRadiusSm,
+      onTap: () {
+        ref.read(noteEditingPageProvider.notifier).updateNote(note);
+        Navigator.of(context).push(
+          AppPageRoute(
+            builder: (context) => const NoteViewingPage(),
+          ),
+        );
+      },
+      padding: AppSpacing.paddingAllSm,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  note.title.isNotEmpty ? note.title : activityName,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              if (note.isFavorite)
+                const Icon(Icons.star, color: Colors.amber, size: 18),
+            ],
+          ),
+          if (note.description.isNotEmpty) ...[
+            AppSpacing.verticalXxs,
+            Text(
+              note.description,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+          AppSpacing.verticalXxs,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Icon(
+                Icons.access_time,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              AppSpacing.horizontalXxs,
+              Text(
+                note.isAllDay
+                    ? l10n.allDay
+                    : '${DateFormat('MMM d', Localizations.localeOf(context).languageCode).format(note.from)}  ${DateFormat('HH:mm').format(note.from)} - ${DateFormat('HH:mm').format(note.to)}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDateRange(ActivityStats stats, String locale) {
+    if (stats.firstOccurrence == null || stats.lastOccurrence == null) {
+      return '-';
+    }
+    final fmt = DateFormat('MMM d', locale);
+    return '${fmt.format(stats.firstOccurrence!)} - ${fmt.format(stats.lastOccurrence!)}';
+  }
+
+  Color _getScoreColor(double percentage) {
+    if (percentage < 0.3) return Colors.red;
+    if (percentage < 0.5) return Colors.orange;
+    if (percentage < 0.7) return Colors.amber;
+    if (percentage < 0.9) return Colors.lightGreen;
+    return Colors.green;
+  }
+}

--- a/lib/features/dashboard/presentation/pages/new_dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/new_dashboard_page.dart
@@ -7,6 +7,7 @@ import 'package:day_tracker/features/dashboard/presentation/widgets/quick_stats_
 import 'package:day_tracker/features/dashboard/presentation/widgets/week_overview_widget.dart';
 import 'package:day_tracker/core/navigation/drawer_index_provider.dart';
 import 'package:day_tracker/features/goals/presentation/widgets/goals_section.dart';
+import 'package:day_tracker/features/dashboard/presentation/widgets/top_activities_widget.dart';
 import 'package:day_tracker/features/habits/presentation/widgets/habits_summary_section.dart';
 import 'package:day_tracker/core/widgets/app_ui_kit.dart';
 import 'package:flutter/material.dart';
@@ -77,9 +78,10 @@ class _NewDashboardPageState extends ConsumerState<NewDashboardPage> {
         SliverToBoxAdapter(child: AppSpacing.verticalMd),
         SliverToBoxAdapter(child: AnimatedListItem(index: 3, child: const WeekOverviewWidget())),
         SliverToBoxAdapter(child: AnimatedListItem(index: 4, child: const FavoritesSectionWidget())),
+        SliverToBoxAdapter(child: AnimatedListItem(index: 5, child: const TopActivitiesWidget())),
         SliverToBoxAdapter(child: AppSpacing.verticalMd),
-        SliverToBoxAdapter(child: AnimatedListItem(index: 5, child: const StatisticsSection())),
-        SliverToBoxAdapter(child: AnimatedListItem(index: 6, child: const InsightsSection())),
+        SliverToBoxAdapter(child: AnimatedListItem(index: 6, child: const StatisticsSection())),
+        SliverToBoxAdapter(child: AnimatedListItem(index: 7, child: const InsightsSection())),
         const SliverToBoxAdapter(child: SizedBox(height: 80)), // Space for FAB
       ],
     );
@@ -101,6 +103,7 @@ class _NewDashboardPageState extends ConsumerState<NewDashboardPage> {
         const SliverToBoxAdapter(child: HabitsSummarySection()),
         SliverToBoxAdapter(child: AppSpacing.verticalMd),
         const SliverToBoxAdapter(child: FavoritesSectionWidget()),
+        const SliverToBoxAdapter(child: TopActivitiesWidget()),
         SliverToBoxAdapter(child: AppSpacing.verticalMd),
         const SliverToBoxAdapter(child: StatisticsSection()),
         const SliverToBoxAdapter(child: InsightsSection()),
@@ -131,6 +134,7 @@ class _NewDashboardPageState extends ConsumerState<NewDashboardPage> {
                   SliverToBoxAdapter(child: AppSpacing.verticalMd),
                   const SliverToBoxAdapter(child: WeekOverviewWidget()),
                   const SliverToBoxAdapter(child: FavoritesSectionWidget()),
+                  const SliverToBoxAdapter(child: TopActivitiesWidget()),
                   SliverToBoxAdapter(child: AppSpacing.verticalMd),
                   const SliverToBoxAdapter(child: StatisticsSection()),
                   const SliverToBoxAdapter(child: SizedBox(height: 80)), // Space for FAB

--- a/lib/features/dashboard/presentation/widgets/top_activities_widget.dart
+++ b/lib/features/dashboard/presentation/widgets/top_activities_widget.dart
@@ -1,0 +1,71 @@
+import 'package:day_tracker/core/widgets/app_ui_kit.dart';
+import 'package:day_tracker/features/dashboard/data/repositories/activity_detail_repository.dart';
+import 'package:day_tracker/features/dashboard/domain/providers/activity_detail_provider.dart';
+import 'package:day_tracker/features/dashboard/presentation/pages/activity_detail_page.dart';
+import 'package:day_tracker/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Displays top activities as clickable cards on the dashboard
+class TopActivitiesWidget extends ConsumerWidget {
+  const TopActivitiesWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activities = ref.watch(topActivitySummariesProvider);
+    final l10n = AppLocalizations.of(context);
+
+    if (activities.isEmpty) return const SizedBox.shrink();
+
+    return AppSection(
+      title: l10n.topActivities,
+      child: Wrap(
+        spacing: AppSpacing.xs,
+        runSpacing: AppSpacing.xs,
+        children: activities.map((activity) {
+          return _ActivityChip(activity: activity);
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class _ActivityChip extends StatelessWidget {
+  const _ActivityChip({required this.activity});
+
+  final ActivitySummary activity;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ActionChip(
+      avatar: CircleAvatar(
+        backgroundColor: activity.category.color,
+        radius: 6,
+      ),
+      label: Text(
+        '${activity.activityName} (${activity.count})',
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface,
+        ),
+      ),
+      backgroundColor: activity.category.color.withValues(alpha: 0.1),
+      side: BorderSide(
+        color: activity.category.color.withValues(alpha: 0.3),
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: AppRadius.borderRadiusXl,
+      ),
+      onPressed: () {
+        Navigator.of(context).push(
+          AppPageRoute(
+            builder: (context) => ActivityDetailPage(
+              activityName: activity.activityName,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -771,5 +771,21 @@
   "moodNeutral": "Neutral",
   "moodPosition": "Stimmungsposition",
   "valenceLabel": "Valenz",
-  "arousalLabel": "Erregung"
+  "arousalLabel": "Erregung",
+
+  "topActivities": "Top-Aktivitäten",
+  "activityDetails": "Aktivitätsdetails",
+  "totalNotes": "Notizen gesamt",
+  "averageRating": "Durchschn.",
+  "associatedDays": "Tage",
+  "dateRange": "Zeitraum",
+  "notesInCategory": "Notizen",
+  "andMoreEntries": "... und {count} weitere",
+  "@andMoreEntries": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1132,5 +1132,21 @@
   "moodNeutral": "Neutral",
   "moodPosition": "Mood Position",
   "valenceLabel": "Valence",
-  "arousalLabel": "Arousal"
+  "arousalLabel": "Arousal",
+
+  "topActivities": "Top Activities",
+  "activityDetails": "Activity Details",
+  "totalNotes": "Total Notes",
+  "averageRating": "Avg. Rating",
+  "associatedDays": "Days",
+  "dateRange": "Date Range",
+  "notesInCategory": "Notes",
+  "andMoreEntries": "... and {count} more",
+  "@andMoreEntries": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4259,6 +4259,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Arousal'**
   String get arousalLabel;
+
+  /// No description provided for @topActivities.
+  ///
+  /// In en, this message translates to:
+  /// **'Top Activities'**
+  String get topActivities;
+
+  /// No description provided for @activityDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Activity Details'**
+  String get activityDetails;
+
+  /// No description provided for @totalNotes.
+  ///
+  /// In en, this message translates to:
+  /// **'Total Notes'**
+  String get totalNotes;
+
+  /// No description provided for @averageRating.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg. Rating'**
+  String get averageRating;
+
+  /// No description provided for @associatedDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Days'**
+  String get associatedDays;
+
+  /// No description provided for @dateRange.
+  ///
+  /// In en, this message translates to:
+  /// **'Date Range'**
+  String get dateRange;
+
+  /// No description provided for @notesInCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Notes'**
+  String get notesInCategory;
+
+  /// No description provided for @andMoreEntries.
+  ///
+  /// In en, this message translates to:
+  /// **'... and {count} more'**
+  String andMoreEntries(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2319,4 +2319,30 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get arousalLabel => 'Erregung';
+
+  @override
+  String get topActivities => 'Top-Aktivitäten';
+
+  @override
+  String get activityDetails => 'Aktivitätsdetails';
+
+  @override
+  String get totalNotes => 'Notizen gesamt';
+
+  @override
+  String get averageRating => 'Durchschn.';
+
+  @override
+  String get associatedDays => 'Tage';
+
+  @override
+  String get dateRange => 'Zeitraum';
+
+  @override
+  String get notesInCategory => 'Notizen';
+
+  @override
+  String andMoreEntries(int count) {
+    return '... und $count weitere';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2291,4 +2291,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get arousalLabel => 'Arousal';
+
+  @override
+  String get topActivities => 'Top Activities';
+
+  @override
+  String get activityDetails => 'Activity Details';
+
+  @override
+  String get totalNotes => 'Total Notes';
+
+  @override
+  String get averageRating => 'Avg. Rating';
+
+  @override
+  String get associatedDays => 'Days';
+
+  @override
+  String get dateRange => 'Date Range';
+
+  @override
+  String get notesInCategory => 'Notes';
+
+  @override
+  String andMoreEntries(int count) {
+    return '... and $count more';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2312,4 +2312,30 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get arousalLabel => 'Activación';
+
+  @override
+  String get topActivities => 'Top Activities';
+
+  @override
+  String get activityDetails => 'Activity Details';
+
+  @override
+  String get totalNotes => 'Total Notes';
+
+  @override
+  String get averageRating => 'Avg. Rating';
+
+  @override
+  String get associatedDays => 'Days';
+
+  @override
+  String get dateRange => 'Date Range';
+
+  @override
+  String get notesInCategory => 'Notes';
+
+  @override
+  String andMoreEntries(int count) {
+    return '... and $count more';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2327,4 +2327,30 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get arousalLabel => 'Activation';
+
+  @override
+  String get topActivities => 'Top Activities';
+
+  @override
+  String get activityDetails => 'Activity Details';
+
+  @override
+  String get totalNotes => 'Total Notes';
+
+  @override
+  String get averageRating => 'Avg. Rating';
+
+  @override
+  String get associatedDays => 'Days';
+
+  @override
+  String get dateRange => 'Date Range';
+
+  @override
+  String get notesInCategory => 'Notes';
+
+  @override
+  String andMoreEntries(int count) {
+    return '... and $count more';
+  }
 }

--- a/test/TEST_COVERAGE.md
+++ b/test/TEST_COVERAGE.md
@@ -1,6 +1,6 @@
 # Test Coverage
 
-**Total: 1001+ passing tests** across 67 test files (+ 16 optional/skipped Supabase integration tests)
+**Total: 1023+ passing tests** across 68 test files (+ 16 optional/skipped Supabase integration tests)
 
 Run all tests with:
 ```bash
@@ -115,8 +115,9 @@ flutter test test/core/ test/features/ test/l10n/ test/integration/
 | `models/dashboard_models_test.dart` | 25 | **StreakData:** empty factory, `isMilestone` (7/30/100/365 and non-milestones), `milestoneValue` (365/100/30/7/0), `copyWith`. **WeekStats:** construction, `copyWith`. **DayScore:** construction, `copyWith`, `moodQuadrant` (defaults null, construction with value, copyWith update). **Insight:** construction (with/without metadata), `copyWith`, InsightType enum values. **DashboardStats:** construction, `copyWith` |
 | `services/mood_correlation_service_test.dart` | 26 | **Correlation Analysis:** Pearson correlation (perfect positive/negative/no correlation/insufficient data/mismatched lengths/zero variance), activity-rating correlation (insufficient days/positive correlation detection/impact calculation/case-insensitive matching), strong correlation finding (empty/sorting/threshold filtering). **Day of Week Analysis:** best/worst day identification, day names, empty handling. **Trend Detection:** insufficient data/improving/declining/stable trends, all trends filtering. **Model Tests:** CorrelationResult (strengthLabel/isPositive), DayOfWeekAnalysis (variance threshold), TrendAnalysis (significance validation) |
 | `providers/granular_providers_test.dart` | 11 | **currentStreakProvider:** returns streak from stats, returns 0 before load, updates on invalidation. **todayLoggedProvider:** returns true/false, returns false before load. **weekAverageProvider:** returns average, returns 0.0 before load, handles zero average. **Selective rebuild:** all providers derive from shared source, consistent values across providers |
+| `repositories/activity_detail_repository_test.dart` | 22 | **getActivityStats:** empty notes/days returns zeros, correct stats for activity with notes (totalNotes/associatedDays/averageDayRating/firstOccurrence/lastOccurrence), zero average when days have no ratings, category from note when notes exist, fallback category when no notes match. **getNotesByActivity:** empty list for no matching notes, filters by activity name, sorted by date descending, empty input. **getDaysByActivity:** empty list when no notes match, returns diary days containing activity, sorted by date descending, handles multiple notes on same day, empty inputs. **extractTopActivitySummaries:** empty list for no notes, sorted by frequency, limits to top 5, includes category color, single note. **ActivityStats:** copyWith preserves/updates fields. **ActivitySummary:** construction with all fields |
 
-**Sources:** `lib/features/dashboard/data/repositories/dashboard_repository.dart`, `data/services/mood_correlation_service.dart`, `data/models/dashboard_stats.dart`, `streak_data.dart`, `week_stats.dart`, `insight.dart`, `lib/features/dashboard/domain/providers/dashboard_stats_provider.dart`
+**Sources:** `lib/features/dashboard/data/repositories/dashboard_repository.dart`, `activity_detail_repository.dart`, `data/services/mood_correlation_service.dart`, `data/models/dashboard_stats.dart`, `streak_data.dart`, `week_stats.dart`, `insight.dart`, `lib/features/dashboard/domain/providers/dashboard_stats_provider.dart`
 
 ### Day Rating (`test/features/day_rating/`)
 
@@ -331,6 +332,7 @@ Workflow-level tests that verify multi-feature provider interactions using `Prov
 | Weekly review status service | Covered | SharedPreferences-based due/shown tracking, mark/clear lifecycle, partial data handling |
 | Widget: NoteEditingPage | Covered | Form fields, category dropdown, checkbox toggle, save actions, editing pre-fill |
 | Widget: DiaryDayWizardPage | Covered | Loading shimmer, tab navigation, tab icons, SafeArea, view switching |
+| Activity detail repository | Covered | ActivityStats/ActivitySummary models, getActivityStats, getNotesByActivity, getDaysByActivity, extractTopActivitySummaries |
 | Dashboard granular providers | Covered | currentStreakProvider, todayLoggedProvider, weekAverageProvider: value extraction, default before load, selective rebuild |
 | Widget: NewDashboardPage | Covered | FAB, RefreshIndicator, responsive layout, custom stats rendering |
 | Widget: SettingsPage | Covered | Settings title, all 6 settings sections, category management, scrollability |

--- a/test/features/dashboard/repositories/activity_detail_repository_test.dart
+++ b/test/features/dashboard/repositories/activity_detail_repository_test.dart
@@ -1,0 +1,398 @@
+import 'package:day_tracker/features/dashboard/data/repositories/activity_detail_repository.dart';
+import 'package:day_tracker/features/day_rating/data/models/day_rating.dart';
+import 'package:day_tracker/features/day_rating/data/models/diary_day.dart';
+import 'package:day_tracker/features/notes/data/models/note.dart';
+import 'package:day_tracker/features/notes/data/models/note_category.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late ActivityDetailRepository repository;
+
+  setUp(() {
+    repository = ActivityDetailRepository();
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  final workCategory = NoteCategory(title: 'Work', color: Colors.purple);
+  final leisureCategory = NoteCategory(title: 'Leisure', color: Colors.lightBlue);
+  final foodCategory = NoteCategory(title: 'Food', color: Colors.amber);
+
+  Note createNote({
+    required String title,
+    required NoteCategory category,
+    required DateTime date,
+  }) {
+    return Note(
+      title: title,
+      description: 'Test description',
+      from: date,
+      to: date.add(const Duration(hours: 1)),
+      noteCategory: category,
+    );
+  }
+
+  DiaryDay createDiaryDay(DateTime date, {int score = 3, List<Note>? notes}) {
+    final day = DiaryDay(
+      day: date,
+      ratings: [
+        DayRating(dayRating: DayRatings.social, score: score),
+        DayRating(dayRating: DayRatings.productivity, score: score),
+        DayRating(dayRating: DayRatings.sport, score: score),
+        DayRating(dayRating: DayRatings.food, score: score),
+      ],
+    );
+    day.notes = notes ?? [];
+    return day;
+  }
+
+  // ── getActivityStats ─────────────────────────────────────────────
+
+  group('getActivityStats', () {
+    test('empty notes and days returns zeros', () {
+      final stats = repository.getActivityStats(
+        activityName: 'Work',
+        notes: [],
+        diaryDays: [],
+      );
+
+      expect(stats.activityName, 'Work');
+      expect(stats.totalNotes, 0);
+      expect(stats.associatedDays, 0);
+      expect(stats.averageDayRating, 0);
+      expect(stats.firstOccurrence, isNull);
+      expect(stats.lastOccurrence, isNull);
+    });
+
+    test('calculates correct stats for activity with notes', () {
+      final date1 = DateTime(2026, 1, 10);
+      final date2 = DateTime(2026, 1, 15);
+      final date3 = DateTime(2026, 1, 20);
+
+      final notes = [
+        createNote(title: 'Meeting', category: workCategory, date: date1),
+        createNote(title: 'Coding', category: workCategory, date: date2),
+        createNote(title: 'Review', category: workCategory, date: date3),
+        createNote(title: 'Movie', category: leisureCategory, date: date1),
+      ];
+
+      final diaryDays = [
+        createDiaryDay(date1, score: 4),
+        createDiaryDay(date2, score: 3),
+        createDiaryDay(date3, score: 5),
+      ];
+
+      final stats = repository.getActivityStats(
+        activityName: 'Work',
+        notes: notes,
+        diaryDays: diaryDays,
+      );
+
+      expect(stats.activityName, 'Work');
+      expect(stats.totalNotes, 3);
+      expect(stats.associatedDays, 3);
+      expect(stats.averageDayRating, 16.0); // (16 + 12 + 20) / 3 = 16
+      expect(stats.firstOccurrence, date1);
+      expect(stats.lastOccurrence, date3);
+      expect(stats.category.title, 'Work');
+    });
+
+    test('returns zero average when days have no ratings', () {
+      final date1 = DateTime(2026, 1, 10);
+      final notes = [
+        createNote(title: 'Meeting', category: workCategory, date: date1),
+      ];
+      final diaryDays = [
+        DiaryDay(day: date1, ratings: []),
+      ];
+
+      final stats = repository.getActivityStats(
+        activityName: 'Work',
+        notes: notes,
+        diaryDays: diaryDays,
+      );
+
+      expect(stats.averageDayRating, 0);
+    });
+
+    test('category comes from note when notes exist', () {
+      final date1 = DateTime(2026, 1, 10);
+      final notes = [
+        createNote(title: 'Work item', category: workCategory, date: date1),
+      ];
+
+      final stats = repository.getActivityStats(
+        activityName: 'Work',
+        notes: notes,
+        diaryDays: [],
+      );
+
+      expect(stats.category.color, Colors.purple);
+    });
+
+    test('uses fallback category when no notes match', () {
+      final stats = repository.getActivityStats(
+        activityName: 'Unknown',
+        notes: [],
+        diaryDays: [],
+      );
+
+      expect(stats.category.title, 'Unknown');
+    });
+  });
+
+  // ── getNotesByActivity ───────────────────────────────────────────
+
+  group('getNotesByActivity', () {
+    test('returns empty list for no matching notes', () {
+      final notes = [
+        createNote(title: 'Movie', category: leisureCategory, date: DateTime(2026, 1, 10)),
+      ];
+
+      final result = repository.getNotesByActivity('Work', notes);
+      expect(result, isEmpty);
+    });
+
+    test('filters notes by activity name', () {
+      final notes = [
+        createNote(title: 'Meeting', category: workCategory, date: DateTime(2026, 1, 10)),
+        createNote(title: 'Movie', category: leisureCategory, date: DateTime(2026, 1, 11)),
+        createNote(title: 'Coding', category: workCategory, date: DateTime(2026, 1, 12)),
+      ];
+
+      final result = repository.getNotesByActivity('Work', notes);
+      expect(result.length, 2);
+      expect(result.every((n) => n.noteCategory.title == 'Work'), true);
+    });
+
+    test('returns notes sorted by date descending', () {
+      final date1 = DateTime(2026, 1, 10);
+      final date2 = DateTime(2026, 1, 15);
+      final date3 = DateTime(2026, 1, 12);
+
+      final notes = [
+        createNote(title: 'A', category: workCategory, date: date1),
+        createNote(title: 'B', category: workCategory, date: date2),
+        createNote(title: 'C', category: workCategory, date: date3),
+      ];
+
+      final result = repository.getNotesByActivity('Work', notes);
+      expect(result[0].title, 'B'); // Jan 15 (newest)
+      expect(result[1].title, 'C'); // Jan 12
+      expect(result[2].title, 'A'); // Jan 10 (oldest)
+    });
+
+    test('returns empty list for empty input', () {
+      final result = repository.getNotesByActivity('Work', []);
+      expect(result, isEmpty);
+    });
+  });
+
+  // ── getDaysByActivity ────────────────────────────────────────────
+
+  group('getDaysByActivity', () {
+    test('returns empty list when no notes match', () {
+      final notes = [
+        createNote(title: 'Movie', category: leisureCategory, date: DateTime(2026, 1, 10)),
+      ];
+      final diaryDays = [createDiaryDay(DateTime(2026, 1, 10))];
+
+      final result = repository.getDaysByActivity('Work', notes, diaryDays);
+      expect(result, isEmpty);
+    });
+
+    test('returns diary days that contain the activity', () {
+      final date1 = DateTime(2026, 1, 10);
+      final date2 = DateTime(2026, 1, 11);
+      final date3 = DateTime(2026, 1, 12);
+
+      final notes = [
+        createNote(title: 'Meeting', category: workCategory, date: date1),
+        createNote(title: 'Movie', category: leisureCategory, date: date2),
+        createNote(title: 'Coding', category: workCategory, date: date3),
+      ];
+
+      final diaryDays = [
+        createDiaryDay(date1),
+        createDiaryDay(date2),
+        createDiaryDay(date3),
+      ];
+
+      final result = repository.getDaysByActivity('Work', notes, diaryDays);
+      expect(result.length, 2);
+    });
+
+    test('returns days sorted by date descending', () {
+      final date1 = DateTime(2026, 1, 10);
+      final date2 = DateTime(2026, 1, 15);
+
+      final notes = [
+        createNote(title: 'A', category: workCategory, date: date1),
+        createNote(title: 'B', category: workCategory, date: date2),
+      ];
+
+      final diaryDays = [
+        createDiaryDay(date1),
+        createDiaryDay(date2),
+      ];
+
+      final result = repository.getDaysByActivity('Work', notes, diaryDays);
+      expect(result[0].day, date2); // newest first
+      expect(result[1].day, date1);
+    });
+
+    test('handles multiple notes on same day', () {
+      final date = DateTime(2026, 1, 10);
+
+      final notes = [
+        createNote(title: 'Meeting 1', category: workCategory, date: date),
+        createNote(title: 'Meeting 2', category: workCategory, date: date.add(const Duration(hours: 2))),
+      ];
+
+      final diaryDays = [createDiaryDay(date)];
+
+      final result = repository.getDaysByActivity('Work', notes, diaryDays);
+      expect(result.length, 1); // same day, not duplicated
+    });
+
+    test('returns empty list for empty inputs', () {
+      final result = repository.getDaysByActivity('Work', [], []);
+      expect(result, isEmpty);
+    });
+  });
+
+  // ── extractTopActivitySummaries ──────────────────────────────────
+
+  group('extractTopActivitySummaries', () {
+    test('returns empty list for no notes', () {
+      final result = repository.extractTopActivitySummaries([], []);
+      expect(result, isEmpty);
+    });
+
+    test('returns activities sorted by frequency', () {
+      final notes = [
+        createNote(title: 'A', category: workCategory, date: DateTime(2026, 1, 1)),
+        createNote(title: 'B', category: workCategory, date: DateTime(2026, 1, 2)),
+        createNote(title: 'C', category: workCategory, date: DateTime(2026, 1, 3)),
+        createNote(title: 'D', category: leisureCategory, date: DateTime(2026, 1, 1)),
+        createNote(title: 'E', category: foodCategory, date: DateTime(2026, 1, 1)),
+        createNote(title: 'F', category: foodCategory, date: DateTime(2026, 1, 2)),
+      ];
+
+      final result = repository.extractTopActivitySummaries(notes, []);
+      expect(result.length, 3);
+      expect(result[0].activityName, 'Work');
+      expect(result[0].count, 3);
+      expect(result[1].activityName, 'Food');
+      expect(result[1].count, 2);
+      expect(result[2].activityName, 'Leisure');
+      expect(result[2].count, 1);
+    });
+
+    test('limits to top 5 activities', () {
+      final categories = List.generate(7, (i) =>
+          NoteCategory(title: 'Cat$i', color: Colors.blue));
+      final notes = <Note>[];
+      for (var i = 0; i < 7; i++) {
+        for (var j = 0; j <= i; j++) {
+          notes.add(createNote(
+            title: 'Note$i-$j',
+            category: categories[i],
+            date: DateTime(2026, 1, j + 1),
+          ));
+        }
+      }
+
+      final result = repository.extractTopActivitySummaries(notes, []);
+      expect(result.length, 5);
+    });
+
+    test('includes category color from notes', () {
+      final notes = [
+        createNote(title: 'A', category: workCategory, date: DateTime(2026, 1, 1)),
+      ];
+
+      final result = repository.extractTopActivitySummaries(notes, []);
+      expect(result[0].category.color, Colors.purple);
+    });
+
+    test('single note returns single activity', () {
+      final notes = [
+        createNote(title: 'A', category: workCategory, date: DateTime(2026, 1, 1)),
+      ];
+
+      final result = repository.extractTopActivitySummaries(notes, []);
+      expect(result.length, 1);
+      expect(result[0].activityName, 'Work');
+      expect(result[0].count, 1);
+    });
+  });
+
+  // ── ActivityStats model ──────────────────────────────────────────
+
+  group('ActivityStats', () {
+    test('copyWith preserves unchanged fields', () {
+      final stats = ActivityStats(
+        activityName: 'Work',
+        category: workCategory,
+        totalNotes: 5,
+        associatedDays: 3,
+        averageDayRating: 15.0,
+        firstOccurrence: DateTime(2026, 1, 1),
+        lastOccurrence: DateTime(2026, 1, 31),
+      );
+
+      final copied = stats.copyWith(totalNotes: 10);
+      expect(copied.activityName, 'Work');
+      expect(copied.totalNotes, 10);
+      expect(copied.associatedDays, 3);
+      expect(copied.averageDayRating, 15.0);
+    });
+
+    test('copyWith updates all fields', () {
+      final stats = ActivityStats(
+        activityName: 'Work',
+        category: workCategory,
+        totalNotes: 5,
+        associatedDays: 3,
+        averageDayRating: 15.0,
+      );
+
+      final newDate = DateTime(2026, 2, 1);
+      final copied = stats.copyWith(
+        activityName: 'Leisure',
+        category: leisureCategory,
+        totalNotes: 10,
+        associatedDays: 7,
+        averageDayRating: 18.0,
+        firstOccurrence: newDate,
+        lastOccurrence: newDate,
+      );
+
+      expect(copied.activityName, 'Leisure');
+      expect(copied.category.title, 'Leisure');
+      expect(copied.totalNotes, 10);
+      expect(copied.associatedDays, 7);
+      expect(copied.averageDayRating, 18.0);
+      expect(copied.firstOccurrence, newDate);
+      expect(copied.lastOccurrence, newDate);
+    });
+  });
+
+  // ── ActivitySummary model ────────────────────────────────────────
+
+  group('ActivitySummary', () {
+    test('construction with all fields', () {
+      final summary = ActivitySummary(
+        activityName: 'Work',
+        category: workCategory,
+        count: 5,
+      );
+
+      expect(summary.activityName, 'Work');
+      expect(summary.category.color, Colors.purple);
+      expect(summary.count, 5);
+    });
+  });
+}


### PR DESCRIPTION
…ashboard (#119)

Add TopActivitiesWidget to dashboard showing top 5 note categories as clickable chips. Clicking navigates to ActivityDetailPage displaying summary stats (total notes, associated days, average rating, date range), diary day list, and notes list. Includes 22 unit tests.